### PR TITLE
feat(E4-3): レビュー編集・削除機能実装

### DIFF
--- a/app/_actions/review.ts
+++ b/app/_actions/review.ts
@@ -7,8 +7,10 @@ import { ApiError, handleApiError } from '@/lib/api/error';
 import { API_ERROR_CODES, type ApiResponse } from '@/lib/types/api';
 import {
   createReviewSchema,
+  updateReviewSchema,
   getChannelReviewsSchema,
   type CreateReviewInput,
+  type UpdateReviewInput,
 } from '@/lib/validations/review';
 import type { Review, PaginatedReviews, ReviewWithUser } from '@/lib/types/review';
 
@@ -166,6 +168,139 @@ export async function getChannelReviewsAction(
           totalPages,
         },
       },
+    };
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+/**
+ * レビューを更新
+ */
+export async function updateReviewAction(
+  reviewId: string,
+  input: UpdateReviewInput
+): Promise<ApiResponse<Review>> {
+  try {
+    // バリデーション
+    const validated = updateReviewSchema.parse(input);
+
+    // 認証チェック
+    const user = await getUser();
+    if (!user) {
+      throw new ApiError(
+        API_ERROR_CODES.UNAUTHORIZED,
+        'ログインが必要です',
+        401
+      );
+    }
+
+    // Supabaseクライアント作成
+    const supabase = await createClient();
+
+    // レビューを更新（RLSで自分のレビューのみ更新可能）
+    const { data, error } = await supabase
+      .from('reviews')
+      .update({
+        rating: validated.rating,
+        title: validated.title || null,
+        content: validated.content,
+        is_spoiler: validated.isSpoiler || false,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', reviewId)
+      .eq('user_id', user.id) // 自分のレビューのみ更新
+      .select()
+      .single();
+
+    if (error) {
+      // レコードが見つからない、または権限がない
+      if (error.code === 'PGRST116') {
+        throw new ApiError(
+          API_ERROR_CODES.FORBIDDEN,
+          'このレビューを編集する権限がありません',
+          403
+        );
+      }
+
+      console.error('Supabase error:', error);
+      throw new ApiError(
+        API_ERROR_CODES.INTERNAL_ERROR,
+        'レビューの更新に失敗しました',
+        500
+      );
+    }
+
+    // チャンネル詳細ページを再検証
+    revalidatePath(`/channels/${data.channel_id}`);
+
+    return {
+      success: true,
+      data,
+    };
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+/**
+ * レビューを削除（ソフトデリート）
+ */
+export async function deleteReviewAction(
+  reviewId: string
+): Promise<ApiResponse<void>> {
+  try {
+    // 認証チェック
+    const user = await getUser();
+    if (!user) {
+      throw new ApiError(
+        API_ERROR_CODES.UNAUTHORIZED,
+        'ログインが必要です',
+        401
+      );
+    }
+
+    // Supabaseクライアント作成
+    const supabase = await createClient();
+
+    // レビューのchannel_idを取得（再検証用）
+    const { data: review, error: fetchError } = await supabase
+      .from('reviews')
+      .select('channel_id')
+      .eq('id', reviewId)
+      .eq('user_id', user.id)
+      .single();
+
+    if (fetchError || !review) {
+      throw new ApiError(
+        API_ERROR_CODES.FORBIDDEN,
+        'このレビューを削除する権限がありません',
+        403
+      );
+    }
+
+    // ソフトデリート（deleted_atを設定）
+    const { error } = await supabase
+      .from('reviews')
+      .update({ deleted_at: new Date().toISOString() })
+      .eq('id', reviewId)
+      .eq('user_id', user.id); // 自分のレビューのみ削除
+
+    if (error) {
+      console.error('Supabase error:', error);
+      throw new ApiError(
+        API_ERROR_CODES.INTERNAL_ERROR,
+        'レビューの削除に失敗しました',
+        500
+      );
+    }
+
+    // チャンネル詳細ページを再検証
+    revalidatePath(`/channels/${review.channel_id}`);
+
+    return {
+      success: true,
+      data: undefined,
     };
   } catch (err) {
     return handleApiError(err);

--- a/app/_components/delete-review-dialog.tsx
+++ b/app/_components/delete-review-dialog.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+interface DeleteReviewDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  isLoading?: boolean;
+}
+
+/**
+ * レビュー削除確認ダイアログ
+ * ユーザーにレビュー削除の確認を求めます
+ */
+export default function DeleteReviewDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  isLoading = false,
+}: DeleteReviewDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>レビューを削除しますか？</AlertDialogTitle>
+          <AlertDialogDescription>
+            この操作は取り消すことができません。レビューは完全に削除されます。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isLoading}>
+            キャンセル
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault();
+              onConfirm();
+            }}
+            disabled={isLoading}
+            className="bg-red-600 hover:bg-red-700"
+          >
+            {isLoading ? '削除中...' : '削除'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/app/_components/review-edit-dialog.tsx
+++ b/app/_components/review-edit-dialog.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { StarRating } from './star-rating';
+import { updateReviewAction } from '@/app/_actions/review';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useToast } from '@/hooks/use-toast';
+import { Loader2 } from 'lucide-react';
+import type { ReviewWithUser } from '@/lib/types/review';
+
+interface ReviewEditDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  review: ReviewWithUser;
+}
+
+/**
+ * レビュー編集ダイアログ
+ * モーダル内でレビューを編集できます
+ */
+export default function ReviewEditDialog({
+  open,
+  onOpenChange,
+  review,
+}: ReviewEditDialogProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [rating, setRating] = useState<number>(review.rating);
+  const [title, setTitle] = useState<string>(review.title || '');
+  const [content, setContent] = useState<string>(review.content);
+  const [isSpoiler, setIsSpoiler] = useState<boolean>(review.is_spoiler);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [errors, setErrors] = useState<{
+    rating?: string;
+    title?: string;
+    content?: string;
+  }>({});
+
+  // ダイアログが開かれた時にフォームをリセット
+  useEffect(() => {
+    if (open) {
+      setRating(review.rating);
+      setTitle(review.title || '');
+      setContent(review.content);
+      setIsSpoiler(review.is_spoiler);
+      setErrors({});
+    }
+  }, [open, review]);
+
+  const validateForm = (): boolean => {
+    const newErrors: typeof errors = {};
+
+    if (rating === 0) {
+      newErrors.rating = '評価を選択してください';
+    }
+
+    if (content.length < 50) {
+      newErrors.content = 'レビュー本文は50文字以上で入力してください';
+    }
+
+    if (content.length > 2000) {
+      newErrors.content = 'レビュー本文は2000文字以内で入力してください';
+    }
+
+    if (title.length > 100) {
+      newErrors.title = 'タイトルは100文字以内で入力してください';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const result = await updateReviewAction(review.id, {
+        rating,
+        title: title || undefined,
+        content,
+        isSpoiler,
+      });
+
+      if (result.success) {
+        toast({
+          title: 'レビューを更新しました',
+          description: 'レビューが正常に更新されました',
+        });
+
+        onOpenChange(false);
+        router.refresh();
+      } else {
+        toast({
+          title: 'エラー',
+          description: result.error || 'レビューの更新に失敗しました',
+          variant: 'destructive',
+        });
+      }
+    } catch (error) {
+      console.error('Review update error:', error);
+      toast({
+        title: 'エラー',
+        description: '予期しないエラーが発生しました',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>レビューを編集</DialogTitle>
+          <DialogDescription>
+            レビューの内容を編集できます
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {/* 星評価 */}
+          <div>
+            <Label htmlFor="rating" className="text-base font-semibold mb-2 block">
+              評価 <span className="text-red-500">*</span>
+            </Label>
+            <StarRating rating={rating} onRatingChange={setRating} size={32} />
+            {errors.rating && (
+              <p className="text-sm text-red-500 mt-1">{errors.rating}</p>
+            )}
+          </div>
+
+          {/* タイトル（オプション） */}
+          <div>
+            <Label htmlFor="title" className="text-base font-semibold mb-2 block">
+              タイトル（オプション）
+            </Label>
+            <Input
+              id="title"
+              type="text"
+              placeholder="例: とても参考になるチャンネル"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              maxLength={100}
+              disabled={isSubmitting}
+            />
+            <p className="text-sm text-content-secondary mt-1">
+              {title.length} / 100文字
+            </p>
+            {errors.title && (
+              <p className="text-sm text-red-500 mt-1">{errors.title}</p>
+            )}
+          </div>
+
+          {/* レビュー本文 */}
+          <div>
+            <Label htmlFor="content" className="text-base font-semibold mb-2 block">
+              レビュー本文 <span className="text-red-500">*</span>
+            </Label>
+            <Textarea
+              id="content"
+              placeholder="このチャンネルについての感想を50文字以上で入力してください..."
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              rows={8}
+              maxLength={2000}
+              disabled={isSubmitting}
+              className="resize-none"
+            />
+            <p
+              className={`text-sm mt-1 ${
+                content.length < 50
+                  ? 'text-red-500'
+                  : content.length >= 50 && content.length <= 2000
+                    ? 'text-green-600'
+                    : 'text-content-secondary'
+              }`}
+            >
+              {content.length} / 2000文字
+              {content.length < 50 && ` (あと${50 - content.length}文字必要)`}
+            </p>
+            {errors.content && (
+              <p className="text-sm text-red-500 mt-1">{errors.content}</p>
+            )}
+          </div>
+
+          {/* ネタバレフラグ */}
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="isSpoiler"
+              checked={isSpoiler}
+              onChange={(e) => setIsSpoiler(e.target.checked)}
+              disabled={isSubmitting}
+              className="w-4 h-4"
+            />
+            <Label htmlFor="isSpoiler" className="text-sm cursor-pointer">
+              ネタバレを含む
+            </Label>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              キャンセル
+            </Button>
+            <Button
+              type="submit"
+              disabled={isSubmitting || rating === 0 || content.length < 50}
+              className="bg-accent hover:bg-accent-hover"
+            >
+              {isSubmitting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  更新中...
+                </>
+              ) : (
+                '更新'
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/_components/review-list.tsx
+++ b/app/_components/review-list.tsx
@@ -1,8 +1,13 @@
 'use client';
 
-import { PaginatedReviews } from '@/lib/types/review';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { PaginatedReviews, ReviewWithUser } from '@/lib/types/review';
 import ReviewCard from './review-card';
 import Pagination from './pagination';
+import ReviewEditDialog from './review-edit-dialog';
+import DeleteReviewDialog from './delete-review-dialog';
+import { deleteReviewAction } from '@/app/_actions/review';
 import { useToast } from '@/hooks/use-toast';
 
 interface ReviewListProps {
@@ -20,22 +25,58 @@ export default function ReviewList({
   channelId,
   currentUserId,
 }: ReviewListProps) {
+  const router = useRouter();
   const { toast } = useToast();
+  const [editingReview, setEditingReview] = useState<ReviewWithUser | null>(
+    null
+  );
+  const [deletingReviewId, setDeletingReviewId] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
 
-  const handleEdit = () => {
-    // E4-3で実装予定
-    toast({
-      title: '編集機能は未実装です',
-      description: 'E4-3で実装予定',
-    });
+  const handleEdit = (reviewId: string) => {
+    const review = initialData.reviews.find((r) => r.id === reviewId);
+    if (review) {
+      setEditingReview(review);
+    }
   };
 
-  const handleDelete = async () => {
-    // E4-4で実装予定
-    toast({
-      title: '削除機能は未実装です',
-      description: 'E4-4で実装予定',
-    });
+  const handleDelete = (reviewId: string) => {
+    setDeletingReviewId(reviewId);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!deletingReviewId) return;
+
+    setIsDeleting(true);
+
+    try {
+      const result = await deleteReviewAction(deletingReviewId);
+
+      if (result.success) {
+        toast({
+          title: 'レビューを削除しました',
+          description: 'レビューが正常に削除されました',
+        });
+
+        setDeletingReviewId(null);
+        router.refresh();
+      } else {
+        toast({
+          title: 'エラー',
+          description: result.error || 'レビューの削除に失敗しました',
+          variant: 'destructive',
+        });
+      }
+    } catch (error) {
+      console.error('Review delete error:', error);
+      toast({
+        title: 'エラー',
+        description: '予期しないエラーが発生しました',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsDeleting(false);
+    }
   };
 
   if (initialData.reviews.length === 0) {
@@ -48,26 +89,45 @@ export default function ReviewList({
   }
 
   return (
-    <div>
-      <div className="space-y-4">
-        {initialData.reviews.map((review) => (
-          <ReviewCard
-            key={review.id}
-            review={review}
-            currentUserId={currentUserId}
-            onEdit={handleEdit}
-            onDelete={handleDelete}
+    <>
+      <div>
+        <div className="space-y-4">
+          {initialData.reviews.map((review) => (
+            <ReviewCard
+              key={review.id}
+              review={review}
+              currentUserId={currentUserId}
+              onEdit={() => handleEdit(review.id)}
+              onDelete={() => handleDelete(review.id)}
+            />
+          ))}
+        </div>
+
+        {initialData.pagination.totalPages > 1 && (
+          <Pagination
+            currentPage={initialData.pagination.page}
+            totalPages={initialData.pagination.totalPages}
+            baseUrl={`/channels/${channelId}`}
           />
-        ))}
+        )}
       </div>
 
-      {initialData.pagination.totalPages > 1 && (
-        <Pagination
-          currentPage={initialData.pagination.page}
-          totalPages={initialData.pagination.totalPages}
-          baseUrl={`/channels/${channelId}`}
+      {/* 編集ダイアログ */}
+      {editingReview && (
+        <ReviewEditDialog
+          open={!!editingReview}
+          onOpenChange={(open) => !open && setEditingReview(null)}
+          review={editingReview}
         />
       )}
-    </div>
+
+      {/* 削除確認ダイアログ */}
+      <DeleteReviewDialog
+        open={!!deletingReviewId}
+        onOpenChange={(open) => !open && setDeletingReviewId(null)}
+        onConfirm={handleConfirmDelete}
+        isLoading={isDeleting}
+      />
+    </>
   );
 }

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -1,0 +1,196 @@
+"use client"
+
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
+  size?: "default" | "sm"
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "text-lg font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "bg-muted mb-2 inline-flex size-16 items-center justify-center rounded-md sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Action
+        data-slot="alert-dialog-action"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Cancel
+        data-slot="alert-dialog-cancel"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}


### PR DESCRIPTION
## 概要
自分が投稿したレビューを編集・削除できる機能を実装しました。

Closes #23

## 実装内容

### Server Actions

#### updateReviewAction
- Zodバリデーション（updateReviewSchema）
- 認証チェック（getUser）
- RLS権限チェック（user_id照合）
- レビュー更新処理
- revalidatePathで再検証

#### deleteReviewAction
- 認証チェック（getUser）
- ソフトデリート（deleted_at設定）
- RLS権限チェック（user_id照合）
- revalidatePathで再検証

### コンポーネント

#### ReviewEditDialog
- **機能**: モーダルダイアログでレビュー編集
- **フォーム**: 星評価、タイトル、本文、ネタバレフラグ
- **バリデーション**: クライアント側検証
- **状態管理**: useState、useEffect
- **UI**: 既存データで自動入力、ローディング状態表示

#### DeleteReviewDialog
- **機能**: 削除確認ダイアログ
- **UI**: 警告メッセージ、キャンセル/削除ボタン
- **状態**: ローディング状態表示
- **カラー**: 削除ボタンは赤色（bg-red-600）

#### ReviewList（更新）
- 編集・削除ハンドラー実装
- ダイアログ状態管理
- トースト通知
- router.refresh()でページ再読み込み

### UIコンポーネント追加

- `components/ui/dialog.tsx` - shadcn/ui Dialog
- `components/ui/alert-dialog.tsx` - shadcn/ui AlertDialog

## 主な機能

✅ **編集機能**
- 編集ボタンクリックでモーダル表示
- 既存データで自動入力
- フォームバリデーション
- 成功時にトースト通知とページ再読み込み

✅ **削除機能**
- 削除ボタンクリックで確認ダイアログ表示
- ソフトデリート（deleted_at設定）
- 削除後、一覧から非表示
- 成功時にトースト通知とページ再読み込み

✅ **権限管理**
- 自分のレビューのみ編集・削除ボタン表示
- RLSで二重チェック
- 他人のレビューは編集・削除不可

✅ **UX**
- ローディング状態表示
- 楽観的UI更新（router.refresh）
- 成功/エラートースト

## セキュリティ

### 4層防御アーキテクチャ
1. **クライアント側**: ボタン表示制御（currentUserId照合）
2. **Zodバリデーション**: 入力値検証
3. **RLS**: user_id = auth.uid() チェック
4. **DB制約**: NOT NULL、CHECK制約

### 権限チェック
- フロントエンド: 自分のレビューのみボタン表示
- バックエンド: user_id照合でダブルチェック
- RLS: Supabaseレベルでアクセス制御

### ソフトデリート
- 物理削除せずdeleted_at設定
- データ復元可能
- 監査ログ保持

## テスト結果

- ✅ TypeScript: エラーなし
- ✅ ESLint: エラーなし
- ✅ Next.js Build: 成功

## 今後の改善点

- E2Eテスト追加（今後のPRで実装予定）
- 編集履歴機能（将来的な機能拡張）
- 削除取り消し機能（管理者向け）

## スクリーンショット

（手動テスト後に追加予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)