### PR TITLE
feat(E5-1): マイリスト作成・管理機能実装

### DIFF
--- a/app/_actions/list.ts
+++ b/app/_actions/list.ts
@@ -1,0 +1,255 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { createClient } from '@/lib/supabase/server';
+import { getUser } from '@/lib/auth';
+import { ApiError, handleApiError } from '@/lib/api/error';
+import { API_ERROR_CODES, type ApiResponse } from '@/lib/types/api';
+import {
+  createListSchema,
+  updateListSchema,
+  type CreateListInput,
+  type UpdateListInput,
+} from '@/lib/validations/list';
+import type { MyList, PaginatedLists } from '@/lib/types/list';
+
+/**
+ * リストを作成
+ */
+export async function createMyListAction(
+  input: CreateListInput
+): Promise<ApiResponse<MyList>> {
+  try {
+    // バリデーション
+    const validated = createListSchema.parse(input);
+
+    // 認証チェック
+    const user = await getUser();
+    if (!user) {
+      throw new ApiError(
+        API_ERROR_CODES.UNAUTHORIZED,
+        'ログインが必要です',
+        401
+      );
+    }
+
+    // Supabaseクライアント作成
+    const supabase = await createClient();
+
+    // リストを挿入
+    const { data, error } = await supabase
+      .from('lists')
+      .insert({
+        user_id: user.id,
+        name: validated.name,
+        description: validated.description || null,
+        is_public: validated.isPublic || false,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Supabase error:', error);
+      throw new ApiError(
+        API_ERROR_CODES.INTERNAL_ERROR,
+        'リストの作成に失敗しました',
+        500
+      );
+    }
+
+    // マイリストページを再検証
+    revalidatePath('/my-lists');
+
+    return {
+      success: true,
+      data,
+    };
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+/**
+ * リストを更新
+ */
+export async function updateMyListAction(
+  listId: string,
+  input: UpdateListInput
+): Promise<ApiResponse<MyList>> {
+  try {
+    // バリデーション
+    const validated = updateListSchema.parse(input);
+
+    // 認証チェック
+    const user = await getUser();
+    if (!user) {
+      throw new ApiError(
+        API_ERROR_CODES.UNAUTHORIZED,
+        'ログインが必要です',
+        401
+      );
+    }
+
+    // Supabaseクライアント作成
+    const supabase = await createClient();
+
+    // 更新データを構築
+    const updateData: Record<string, unknown> = {};
+    if (validated.name !== undefined) updateData.name = validated.name;
+    if (validated.description !== undefined)
+      updateData.description = validated.description;
+    if (validated.isPublic !== undefined)
+      updateData.isPublic = validated.isPublic;
+
+    // リストを更新（RLSで自分のリストのみ更新可能）
+    const { data, error } = await supabase
+      .from('lists')
+      .update(updateData)
+      .eq('id', listId)
+      .eq('user_id', user.id) // 自分のリストのみ更新
+      .select()
+      .single();
+
+    if (error) {
+      // レコードが見つからない、または権限がない
+      if (error.code === 'PGRST116') {
+        throw new ApiError(
+          API_ERROR_CODES.FORBIDDEN,
+          'このリストを編集する権限がありません',
+          403
+        );
+      }
+
+      console.error('Supabase error:', error);
+      throw new ApiError(
+        API_ERROR_CODES.INTERNAL_ERROR,
+        'リストの更新に失敗しました',
+        500
+      );
+    }
+
+    // マイリストページを再検証
+    revalidatePath('/my-lists');
+
+    return {
+      success: true,
+      data,
+    };
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+/**
+ * リストを削除
+ */
+export async function deleteMyListAction(
+  listId: string
+): Promise<ApiResponse<void>> {
+  try {
+    // 認証チェック
+    const user = await getUser();
+    if (!user) {
+      throw new ApiError(
+        API_ERROR_CODES.UNAUTHORIZED,
+        'ログインが必要です',
+        401
+      );
+    }
+
+    // Supabaseクライアント作成
+    const supabase = await createClient();
+
+    // リストを削除（RLSで自分のリストのみ削除可能）
+    const { error } = await supabase
+      .from('lists')
+      .delete()
+      .eq('id', listId)
+      .eq('user_id', user.id); // 自分のリストのみ削除
+
+    if (error) {
+      console.error('Supabase error:', error);
+      throw new ApiError(
+        API_ERROR_CODES.INTERNAL_ERROR,
+        'リストの削除に失敗しました',
+        500
+      );
+    }
+
+    // マイリストページを再検証
+    revalidatePath('/my-lists');
+
+    return {
+      success: true,
+      data: undefined,
+    };
+  } catch (err) {
+    return handleApiError(err);
+  }
+}
+
+/**
+ * 自分のリスト一覧を取得
+ */
+export async function getMyListsAction(
+  page: number = 1,
+  limit: number = 20
+): Promise<ApiResponse<PaginatedLists>> {
+  try {
+    // 認証チェック
+    const user = await getUser();
+    if (!user) {
+      throw new ApiError(
+        API_ERROR_CODES.UNAUTHORIZED,
+        'ログインが必要です',
+        401
+      );
+    }
+
+    // Supabaseクライアント作成
+    const supabase = await createClient();
+    const offset = (page - 1) * limit;
+
+    // リスト取得
+    const { data: lists, error } = await supabase
+      .from('lists')
+      .select('*')
+      .eq('user_id', user.id)
+      .order('created_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    // 総件数取得
+    const { count, error: countError } = await supabase
+      .from('lists')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', user.id);
+
+    // エラーハンドリング
+    if (error || countError) {
+      console.error('Supabase error:', error || countError);
+      throw new ApiError(
+        API_ERROR_CODES.INTERNAL_ERROR,
+        'リストの取得に失敗しました',
+        500
+      );
+    }
+
+    // ページネーション情報を構築
+    const totalPages = Math.ceil((count || 0) / limit);
+
+    return {
+      success: true,
+      data: {
+        lists: (lists as MyList[]) || [],
+        pagination: {
+          page,
+          limit,
+          total: count || 0,
+          totalPages,
+        },
+      },
+    };
+  } catch (err) {
+    return handleApiError(err);
+  }
+}

--- a/app/_components/list-form-dialog.tsx
+++ b/app/_components/list-form-dialog.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { useToast } from '@/hooks/use-toast';
+import { Loader2 } from 'lucide-react';
+import {
+  createMyListAction,
+  updateMyListAction,
+} from '@/app/_actions/list';
+import type { MyList } from '@/lib/types/list';
+
+interface ListFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  list?: MyList | null; // 編集時はリストを渡す
+}
+
+/**
+ * リスト作成・編集ダイアログ
+ */
+export default function ListFormDialog({
+  open,
+  onOpenChange,
+  list,
+}: ListFormDialogProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [isPublic, setIsPublic] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errors, setErrors] = useState<{
+    name?: string;
+    description?: string;
+  }>({});
+
+  const isEditing = !!list;
+
+  // ダイアログが開かれた時にフォームをリセット
+  useEffect(() => {
+    if (open) {
+      if (list) {
+        setName(list.name);
+        setDescription(list.description || '');
+        setIsPublic(list.is_public);
+      } else {
+        setName('');
+        setDescription('');
+        setIsPublic(false);
+      }
+      setErrors({});
+    }
+  }, [open, list]);
+
+  const validateForm = (): boolean => {
+    const newErrors: typeof errors = {};
+
+    if (name.trim().length === 0) {
+      newErrors.name = 'リスト名を入力してください';
+    } else if (name.length > 50) {
+      newErrors.name = 'リスト名は50文字以内で入力してください';
+    }
+
+    if (description.length > 200) {
+      newErrors.description = '説明は200文字以内で入力してください';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      let result;
+
+      if (isEditing && list) {
+        // 編集
+        result = await updateMyListAction(list.id, {
+          name,
+          description: description || undefined,
+          isPublic,
+        });
+      } else {
+        // 作成
+        result = await createMyListAction({
+          name,
+          description: description || undefined,
+          isPublic,
+        });
+      }
+
+      if (result.success) {
+        toast({
+          title: isEditing ? 'リストを更新しました' : 'リストを作成しました',
+          description: isEditing
+            ? 'リストが正常に更新されました'
+            : 'リストが正常に作成されました',
+        });
+
+        onOpenChange(false);
+        router.refresh();
+      } else {
+        toast({
+          title: 'エラー',
+          description:
+            result.error ||
+            (isEditing
+              ? 'リストの更新に失敗しました'
+              : 'リストの作成に失敗しました'),
+          variant: 'destructive',
+        });
+      }
+    } catch (error) {
+      console.error('List form error:', error);
+      toast({
+        title: 'エラー',
+        description: '予期しないエラーが発生しました',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {isEditing ? 'リストを編集' : '新しいリストを作成'}
+          </DialogTitle>
+          <DialogDescription>
+            {isEditing
+              ? 'リストの情報を編集できます'
+              : 'チャンネルをグループ化するリストを作成します'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* リスト名 */}
+          <div>
+            <Label htmlFor="name" className="text-base font-semibold">
+              リスト名 <span className="text-red-500">*</span>
+            </Label>
+            <Input
+              id="name"
+              type="text"
+              placeholder="例: お気に入りの技術チャンネル"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              maxLength={50}
+              disabled={isSubmitting}
+              className="mt-2"
+            />
+            <p className="text-sm text-content-secondary mt-1">
+              {name.length} / 50文字
+            </p>
+            {errors.name && (
+              <p className="text-sm text-red-500 mt-1">{errors.name}</p>
+            )}
+          </div>
+
+          {/* 説明 */}
+          <div>
+            <Label htmlFor="description" className="text-base font-semibold">
+              説明（オプション）
+            </Label>
+            <Textarea
+              id="description"
+              placeholder="このリストについて簡単に説明してください..."
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={4}
+              maxLength={200}
+              disabled={isSubmitting}
+              className="mt-2 resize-none"
+            />
+            <p className="text-sm text-content-secondary mt-1">
+              {description.length} / 200文字
+            </p>
+            {errors.description && (
+              <p className="text-sm text-red-500 mt-1">{errors.description}</p>
+            )}
+          </div>
+
+          {/* 公開設定 */}
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="isPublic"
+              checked={isPublic}
+              onChange={(e) => setIsPublic(e.target.checked)}
+              disabled={isSubmitting}
+              className="w-4 h-4"
+            />
+            <Label htmlFor="isPublic" className="text-sm cursor-pointer">
+              このリストを公開する
+            </Label>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              キャンセル
+            </Button>
+            <Button
+              type="submit"
+              disabled={isSubmitting || name.trim().length === 0}
+              className="bg-accent hover:bg-accent-hover"
+            >
+              {isSubmitting ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  {isEditing ? '更新中...' : '作成中...'}
+                </>
+              ) : isEditing ? (
+                '更新'
+              ) : (
+                '作成'
+              )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/my-lists/my-lists-client.tsx
+++ b/app/my-lists/my-lists-client.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Plus, Edit, Trash2 } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import ListFormDialog from '@/app/_components/list-form-dialog';
+import DeleteReviewDialog from '@/app/_components/delete-review-dialog';
+import { deleteMyListAction } from '@/app/_actions/list';
+import type { PaginatedLists, MyList } from '@/lib/types/list';
+import { formatDistanceToNow } from 'date-fns';
+import { ja } from 'date-fns/locale';
+
+interface MyListsClientProps {
+  initialData: PaginatedLists;
+  userId: string;
+}
+
+/**
+ * マイリスト管理クライアントコンポーネント
+ */
+export default function MyListsClient({
+  initialData,
+}: MyListsClientProps) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [editingList, setEditingList] = useState<MyList | null>(null);
+  const [deletingListId, setDeletingListId] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleEdit = (list: MyList) => {
+    setEditingList(list);
+  };
+
+  const handleDelete = (listId: string) => {
+    setDeletingListId(listId);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!deletingListId) return;
+
+    setIsDeleting(true);
+
+    try {
+      const result = await deleteMyListAction(deletingListId);
+
+      if (result.success) {
+        toast({
+          title: 'リストを削除しました',
+          description: 'リストが正常に削除されました',
+        });
+
+        setDeletingListId(null);
+        router.refresh();
+      } else {
+        toast({
+          title: 'エラー',
+          description: result.error || 'リストの削除に失敗しました',
+          variant: 'destructive',
+        });
+      }
+    } catch (error) {
+      console.error('List delete error:', error);
+      toast({
+        title: 'エラー',
+        description: '予期しないエラーが発生しました',
+        variant: 'destructive',
+      });
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  if (initialData.lists.length === 0) {
+    return (
+      <>
+        <div className="text-center py-12">
+          <p className="text-gray-500 mb-4">まだリストがありません</p>
+          <Button
+            onClick={() => setShowCreateDialog(true)}
+            className="bg-accent hover:bg-accent-hover"
+          >
+            <Plus className="mr-2 h-4 w-4" />
+            最初のリストを作成
+          </Button>
+        </div>
+
+        <ListFormDialog
+          open={showCreateDialog}
+          onOpenChange={setShowCreateDialog}
+        />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="mb-6 flex justify-between items-center">
+        <p className="text-content-secondary">
+          {initialData.pagination.total} 件のリスト
+        </p>
+        <Button
+          onClick={() => setShowCreateDialog(true)}
+          className="bg-accent hover:bg-accent-hover"
+        >
+          <Plus className="mr-2 h-4 w-4" />
+          新しいリストを作成
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {initialData.lists.map((list) => (
+          <Card key={list.id} className="hover:shadow-lg transition-shadow">
+            <CardHeader>
+              <div className="flex justify-between items-start">
+                <div className="flex-1 min-w-0">
+                  <h3 className="font-semibold text-lg truncate">
+                    {list.name}
+                  </h3>
+                  {list.is_public && (
+                    <span className="inline-block mt-1 px-2 py-1 text-xs bg-blue-100 text-blue-800 rounded">
+                      公開
+                    </span>
+                  )}
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {list.description && (
+                <p className="text-sm text-gray-600 mb-4 line-clamp-2">
+                  {list.description}
+                </p>
+              )}
+
+              <div className="flex items-center justify-between">
+                <p className="text-xs text-gray-500">
+                  {formatDistanceToNow(new Date(list.created_at), {
+                    addSuffix: true,
+                    locale: ja,
+                  })}
+                </p>
+
+                <div className="flex gap-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleEdit(list)}
+                  >
+                    <Edit className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="text-red-600 hover:text-red-700"
+                    onClick={() => handleDelete(list.id)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* 作成ダイアログ */}
+      <ListFormDialog
+        open={showCreateDialog}
+        onOpenChange={setShowCreateDialog}
+      />
+
+      {/* 編集ダイアログ */}
+      {editingList && (
+        <ListFormDialog
+          open={!!editingList}
+          onOpenChange={(open) => !open && setEditingList(null)}
+          list={editingList}
+        />
+      )}
+
+      {/* 削除確認ダイアログ */}
+      <DeleteReviewDialog
+        open={!!deletingListId}
+        onOpenChange={(open) => !open && setDeletingListId(null)}
+        onConfirm={handleConfirmDelete}
+        isLoading={isDeleting}
+      />
+    </>
+  );
+}

--- a/app/my-lists/page.tsx
+++ b/app/my-lists/page.tsx
@@ -1,0 +1,45 @@
+import { redirect } from 'next/navigation';
+import { getUser } from '@/lib/auth';
+import { getMyListsAction } from '@/app/_actions/list';
+import MyListsClient from './my-lists-client';
+
+export const metadata = {
+  title: 'マイリスト | TubeReview',
+  description: 'チャンネルをグループ化して管理',
+};
+
+/**
+ * マイリスト管理ページ
+ */
+export default async function MyListsPage() {
+  // 認証チェック
+  const user = await getUser();
+  if (!user) {
+    redirect('/login');
+  }
+
+  // リスト取得
+  const listsResponse = await getMyListsAction(1, 20);
+  const listsData = listsResponse.success ? listsResponse.data : null;
+
+  return (
+    <div className="min-h-screen bg-base py-8 px-4">
+      <div className="max-w-6xl mx-auto">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-content mb-2">マイリスト</h1>
+          <p className="text-content-secondary">
+            チャンネルをテーマ別にグループ化して管理できます
+          </p>
+        </div>
+
+        {listsData ? (
+          <MyListsClient initialData={listsData} userId={user.id} />
+        ) : (
+          <div className="text-center py-12">
+            <p className="text-red-500">リストの取得に失敗しました</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/types/list.ts
+++ b/lib/types/list.ts
@@ -1,0 +1,25 @@
+/**
+ * リスト型定義
+ */
+export interface MyList {
+  id: string;
+  user_id: string;
+  name: string;
+  description: string | null;
+  is_public: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * ページネーション付きリスト一覧
+ */
+export interface PaginatedLists {
+  lists: MyList[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}

--- a/lib/validations/list.ts
+++ b/lib/validations/list.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+/**
+ * リスト作成時のバリデーションスキーマ
+ */
+export const createListSchema = z.object({
+  name: z
+    .string({ message: 'リスト名は必須です' })
+    .min(1, 'リスト名を入力してください')
+    .max(50, 'リスト名は50文字以内で入力してください')
+    .trim(),
+  description: z
+    .string()
+    .max(200, '説明は200文字以内で入力してください')
+    .trim()
+    .optional(),
+  isPublic: z.boolean().default(false).optional(),
+});
+
+/**
+ * リスト作成入力型
+ */
+export type CreateListInput = z.infer<typeof createListSchema>;
+
+/**
+ * リスト更新時のバリデーションスキーマ
+ */
+export const updateListSchema = z.object({
+  name: z
+    .string({ message: 'リスト名は必須です' })
+    .min(1, 'リスト名を入力してください')
+    .max(50, 'リスト名は50文字以内で入力してください')
+    .trim()
+    .optional(),
+  description: z
+    .string()
+    .max(200, '説明は200文字以内で入力してください')
+    .trim()
+    .optional()
+    .nullable(),
+  isPublic: z.boolean().optional(),
+});
+
+/**
+ * リスト更新入力型
+ */
+export type UpdateListInput = z.infer<typeof updateListSchema>;

--- a/supabase/migrations/20260205000003_create_lists.sql
+++ b/supabase/migrations/20260205000003_create_lists.sql
@@ -1,0 +1,54 @@
+-- マイリスト（リスト）テーブルの作成
+-- ユーザーが独自のテーマでチャンネルをグループ化できる
+
+CREATE TABLE IF NOT EXISTS lists (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name VARCHAR(50) NOT NULL,
+  description VARCHAR(200),
+  is_public BOOLEAN DEFAULT false,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+
+  -- 制約
+  CONSTRAINT lists_name_not_empty CHECK (LENGTH(TRIM(name)) > 0)
+);
+
+-- インデックス
+CREATE INDEX idx_lists_user_id ON lists(user_id);
+CREATE INDEX idx_lists_created_at ON lists(created_at DESC);
+CREATE INDEX idx_lists_public ON lists(is_public) WHERE is_public = true;
+
+-- RLS有効化
+ALTER TABLE lists ENABLE ROW LEVEL SECURITY;
+
+-- RLSポリシー: 自分のリストは読み書き可能
+CREATE POLICY lists_crud_own ON lists
+  FOR ALL
+  USING (auth.uid() = user_id);
+
+-- RLSポリシー: 公開リストは誰でも閲覧可能
+CREATE POLICY lists_select_public ON lists
+  FOR SELECT
+  USING (is_public = true);
+
+-- updated_at自動更新トリガー
+CREATE OR REPLACE FUNCTION update_lists_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_update_lists_updated_at
+  BEFORE UPDATE ON lists
+  FOR EACH ROW
+  EXECUTE FUNCTION update_lists_updated_at();
+
+-- コメント
+COMMENT ON TABLE lists IS 'ユーザーが作成するカスタムリスト';
+COMMENT ON COLUMN lists.user_id IS 'リスト作成者';
+COMMENT ON COLUMN lists.name IS 'リスト名（最大50文字）';
+COMMENT ON COLUMN lists.description IS 'リスト説明（最大200文字）';
+COMMENT ON COLUMN lists.is_public IS '公開設定（true=公開、false=非公開）';


### PR DESCRIPTION
## 概要
チャンネルをテーマ別にグループ化できるカスタムリスト機能を実装しました。

Closes #27

## 実装内容

### データベース

#### listsテーブル作成
- **user_id**: 作成者ID（auth.users参照）
- **name**: リスト名（最大50文字、必須）
- **description**: 説明（最大200文字、オプション）
- **is_public**: 公開設定（boolean、デフォルトfalse）
- **created_at/updated_at**: タイムスタンプ

#### RLSポリシー
```sql
-- 自分のリストは読み書き可能
CREATE POLICY lists_crud_own ON lists FOR ALL USING (auth.uid() = user_id);

-- 公開リストは誰でも閲覧可能
CREATE POLICY lists_select_public ON lists FOR SELECT USING (is_public = true);
```

#### インデックス
- idx_lists_user_id: ユーザーIDによる検索最適化
- idx_lists_created_at: 作成日時による並び替え最適化
- idx_lists_public: 公開リストフィルタリング最適化

### Server Actions

#### createMyListAction
- Zodバリデーション（createListSchema）
- 認証チェック（未ログインユーザーをブロック）
- リスト作成処理
- revalidatePath('/my-lists')

#### updateMyListAction
- Zodバリデーション（updateListSchema）
- 認証・認可チェック
- RLS権限チェック（自分のリストのみ更新可能）
- 部分更新対応

#### deleteMyListAction
- 認証・認可チェック
- RLS権限チェック（自分のリストのみ削除可能）
- 物理削除

#### getMyListsAction
- ページネーション対応（20件/ページ）
- 認証チェック
- 自分のリスト一覧取得

### UIコンポーネント

#### ListFormDialog
- モーダルダイアログで作成・編集
- フォームバリデーション
- 既存データで自動入力（編集時）
- 文字数カウンター
- 公開設定チェックボックス
- ローディング状態表示

#### MyListsClient
- グリッドレイアウト（1/2/3カラム対応）
- リストカード表示
  - リスト名
  - 説明（2行まで表示）
  - 公開バッジ
  - 相対日付（date-fns）
  - 編集・削除ボタン
- 空状態表示
- 作成ボタン

#### /my-lists ページ
- SSR（Server-Side Rendering）
- 認証チェック（未ログイン時はログインページへリダイレクト）
- リスト一覧取得
- クライアントコンポーネントへデータ渡し

### バリデーション
- **createListSchema**: 作成時バリデーション
  - name: 1-50文字、必須、trim
  - description: 0-200文字、オプション、trim
  - isPublic: boolean、デフォルトfalse
  
- **updateListSchema**: 更新時バリデーション
  - name: 1-50文字、オプション、trim
  - description: 0-200文字、オプション、nullable
  - isPublic: boolean、オプション

## 主な機能

✅ **リスト作成**
- リスト名、説明、公開設定を入力
- バリデーション実施
- 成功時トースト通知

✅ **リスト編集**
- 既存データで自動入力
- 部分更新対応
- 自分のリストのみ編集可能

✅ **リスト削除**
- 確認ダイアログ表示
- 自分のリストのみ削除可能
- 成功時トースト通知

✅ **リスト一覧表示**
- グリッドレイアウト
- レスポンシブ対応
- 相対日付表示

✅ **公開設定**
- 公開/非公開切り替え
- 公開リストは将来的に他ユーザーも閲覧可能

## セキュリティ

### 4層防御アーキテクチャ
1. **クライアント側バリデーション**: UX向上
2. **Zodバリデーション**: 型安全な入力検証
3. **RLSポリシー**: Supabaseレベルでアクセス制御
4. **DB制約**: NOT NULL、CHECK制約

### RLS権限チェック
- フロントエンド: 自分のリストのみ操作ボタン表示
- バックエンド: user_id照合でダブルチェック
- RLS: Supabaseレベルでアクセス制御

## テスト結果

- ✅ TypeScript: エラーなし
- ✅ ESLint: エラーなし
- ✅ Next.js Build: 成功
- ✅ /my-lists ページ追加確認

## 今後の改善点

- E2Eテスト追加（今後のPRで実装予定）
- list_channelsテーブルでチャンネル追加機能（E5-2以降）
- リスト詳細ページ（E5-2以降）
- いいね機能（E5-3）

## スクリーンショット

（手動テスト後に追加予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)