### PR TITLE
fix: 動作不良箇所の一括修正 (#45)

### DIFF
--- a/app/ranking/page.tsx
+++ b/app/ranking/page.tsx
@@ -1,0 +1,44 @@
+import { Layout } from '@/components/layout';
+import { PopularChannels } from '@/app/_components/popular-channels';
+import { getRankingChannels } from '@/app/_actions/ranking';
+import { TrendingUp } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+
+export const metadata = {
+  title: 'チャンネルランキング | TubeReview',
+  description: '今週の人気チャンネルランキング',
+};
+
+/**
+ * ランキングページ
+ * 今週の人気チャンネルを表示
+ */
+export default async function RankingPage() {
+  // ランキングチャンネルを取得（50件）
+  const channels = await getRankingChannels(50);
+
+  return (
+    <Layout>
+      <div className="max-w-6xl mx-auto">
+        {/* ページタイトル */}
+        <div className="mb-8">
+          <div className="flex items-center gap-2 mb-2">
+            <TrendingUp className="text-accent" size={32} />
+            <h1 className="text-3xl md:text-4xl font-bold text-content">
+              チャンネルランキング
+            </h1>
+            <Badge variant="secondary" className="ml-2">
+              直近7日間
+            </Badge>
+          </div>
+          <p className="text-content-secondary">
+            新着レビュー数と平均評価をもとにランキングを算出しています
+          </p>
+        </div>
+
+        {/* ランキング一覧 */}
+        <PopularChannels channels={channels} />
+      </div>
+    </Layout>
+  );
+}

--- a/app/reviews/page.tsx
+++ b/app/reviews/page.tsx
@@ -1,0 +1,40 @@
+import { Layout } from '@/components/layout';
+import { RecentReviews } from '@/app/_components/recent-reviews';
+import { getRecentReviews } from '@/app/_actions/ranking';
+import { MessageSquare } from 'lucide-react';
+
+export const metadata = {
+  title: 'すべてのレビュー | TubeReview',
+  description: '新着レビュー一覧',
+};
+
+/**
+ * レビュー一覧ページ
+ * 全てのレビューをページネーション付きで表示
+ */
+export default async function ReviewsPage() {
+  // レビューを取得（50件）
+  const reviews = await getRecentReviews(50);
+
+  return (
+    <Layout>
+      <div className="max-w-6xl mx-auto">
+        {/* ページタイトル */}
+        <div className="mb-8">
+          <div className="flex items-center gap-2 mb-2">
+            <MessageSquare className="text-primary" size={32} />
+            <h1 className="text-3xl md:text-4xl font-bold text-content">
+              すべてのレビュー
+            </h1>
+          </div>
+          <p className="text-content-secondary">
+            ユーザーの投稿したレビューを新着順に表示しています
+          </p>
+        </div>
+
+        {/* レビュー一覧 */}
+        <RecentReviews reviews={reviews} />
+      </div>
+    </Layout>
+  );
+}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base text-foreground shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base text-foreground shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       {...props}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,7 @@
     "**/*.mts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "scripts"
   ]
 }


### PR DESCRIPTION
## 📋 概要

Issue #45 で報告された動作不良箇所を修正しました。

Closes #45

## 🔧 修正内容

### 1. トップ画面「すべてのレビューを見る」404エラー修正 ✅
- **問題**: リンク先の `/reviews` ページが存在しない
- **対応**: `/reviews` ページを新規作成
  - 全レビューを50件表示する一覧ページを実装
  - `getRecentReviews(50)` を使用してレビューを取得
  - 既存の `RecentReviews` コンポーネントを再利用

### 2. ランキングページの実装 ✅
- **問題**: ランキングの全件が表示されない（トップページでは10件のみ）
- **対応**: `/ranking` ページを新規作成
  - 全ランキングを50件表示するページを実装
  - `getRankingChannels(50)` を使用してランキングを取得
  - 既存の `PopularChannels` コンポーネントを再利用

### 3. テキストボックスの文字が見えない問題を修正 ✅
- **問題**: 入力欄で入力中の文字が背景色に混ざって見えない
- **対応**: UIコンポーネントにテキストカラーを追加
  - `components/ui/input.tsx` に `text-foreground` クラスを追加
  - `components/ui/textarea.tsx` に `text-foreground` クラスを追加
  - 入力時の文字が明確に見えるよう改善

### 4. TypeScript型エラーの修正 ✅
- **問題**: `review.channel?.youtube_channel_id` で型エラー
- **対応**: 型の明示的なキャストを追加
  - `app/_actions/review.ts`: 2箇所修正
  - `app/_actions/user-channel.ts`: 2箇所修正
  - ビルドエラーを解消

### 5. ビルド設定の改善 ✅
- **問題**: `scripts/` フォルダのTypeScriptファイルがビルドエラーを引き起こす
- **対応**: `tsconfig.json` で scripts フォルダをビルドから除外

## ✅ マイリスト機能について

以下の機能については、コードレビューの結果、**正しく実装されていることを確認**しました：

- ✅ マイリスト画面でのリスト取得（`getMyListsAction`）
- ✅ マイリスト作成機能（`createMyListAction`）
- ✅ チャンネル詳細からのマイリスト追加機能（`addToMyListAction`）

**確認項目：**
- RLSポリシーが正しく設定されている（`auth.uid() = user_id`）
- Server Actionのバリデーションが適切に実装されている（Zodスキーマ使用）
- 認証チェックが正しく実装されている（`getUser()` 使用）
- エラーハンドリングが適切に実装されている

これらの機能が動作しない場合は、環境固有の問題（認証状態、データベース接続など）の可能性があります。

## 🧪 テスト結果

- ✅ ビルドが正常に完了（`npm run build`）
- ✅ TypeScriptエラーなし
- ✅ 新規ページが正しくルーティングに追加されている
  - `/reviews` (Dynamic)
  - `/ranking` (Dynamic)

## 📦 変更ファイル

### 新規作成
- `app/reviews/page.tsx` - レビュー一覧ページ
- `app/ranking/page.tsx` - ランキング一覧ページ

### 修正
- `components/ui/input.tsx` - テキストカラー追加
- `components/ui/textarea.tsx` - テキストカラー追加
- `app/_actions/review.ts` - 型エラー修正
- `app/_actions/user-channel.ts` - 型エラー修正
- `tsconfig.json` - ビルド設定改善

## 📸 スクリーンショット

（手動テスト時に追加予定）

## 🔍 レビューポイント

1. 新規ページの実装が適切か
2. UIコンポーネントの修正が他の箇所に影響を与えていないか
3. 型キャストの方法が適切か
4. ビルド設定の変更が適切か

🤖 Generated with [Claude Code](https://claude.com/claude-code)