### PR TITLE
style: トップ画面UI改善 - Hero縮小とカード一覧性向上 (#46)

### DIFF
--- a/app/_components/channel-card.tsx
+++ b/app/_components/channel-card.tsx
@@ -19,8 +19,8 @@ export function ChannelCard({ channel }: ChannelCardProps) {
       data-testid="channel-card"
     >
       <Card className="h-full transition-all duration-200 hover:shadow-md hover:-translate-y-1 bg-surface border-stroke">
-        <CardContent className="p-4">
-          <div className="flex gap-4">
+        <CardContent className="p-3">
+          <div className="flex gap-3">
             {/* サムネイル */}
             <div className="flex-shrink-0">
               <Image

--- a/app/_components/hero-section.tsx
+++ b/app/_components/hero-section.tsx
@@ -8,39 +8,31 @@ import { Search, TrendingUp } from 'lucide-react';
  */
 export function HeroSection() {
   return (
-    <section className="text-center space-y-6 py-12">
-      <div className="space-y-4">
-        <h1 className="text-4xl md:text-5xl font-bold text-primary leading-tight">
+    <section className="text-center space-y-4 py-8">
+      <div className="space-y-3">
+        <h1 className="text-3xl md:text-4xl font-bold text-primary leading-tight">
           おすすめに頼らない、
           <br />
           能動的なチャンネル発見
         </h1>
-        <p className="text-lg md:text-xl text-content-secondary max-w-2xl mx-auto leading-relaxed">
+        <p className="text-base md:text-lg text-content-secondary max-w-2xl mx-auto">
           本音のレビューから、あなたにぴったりのチャンネルを見つけよう。
-          <br />
-          ブクログのように「見たい」「見ている」「見た」で管理できます。
         </p>
       </div>
 
-      <div className="flex flex-col sm:flex-row gap-4 justify-center pt-4">
-        <Button asChild size="lg" className="gap-2">
+      <div className="flex flex-col sm:flex-row gap-3 justify-center pt-2">
+        <Button asChild size="default" className="gap-2">
           <Link href="/search">
-            <Search size={20} />
+            <Search size={18} />
             チャンネルを探す
           </Link>
         </Button>
-        <Button asChild variant="outline" size="lg" className="gap-2">
+        <Button asChild variant="outline" size="default" className="gap-2">
           <Link href="#ranking">
-            <TrendingUp size={20} />
+            <TrendingUp size={18} />
             人気ランキングを見る
           </Link>
         </Button>
-      </div>
-
-      <div className="pt-8 space-y-2">
-        <p className="text-sm text-content-secondary">
-          「また時間を無駄にした...」からの脱却
-        </p>
       </div>
     </section>
   );

--- a/app/_components/popular-channels.tsx
+++ b/app/_components/popular-channels.tsx
@@ -40,7 +40,7 @@ export function PopularChannels({ channels }: PopularChannelsProps) {
       </div>
 
       {/* チャンネルグリッド */}
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-5">
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
         {channels.map((channel, index) => (
           <Link
             key={channel.id}
@@ -48,7 +48,7 @@ export function PopularChannels({ channels }: PopularChannelsProps) {
             className="block group"
           >
             <Card className="h-full transition-all duration-300 hover:shadow-md hover:-translate-y-1 bg-surface border-stroke">
-              <CardContent className="p-4 space-y-3">
+              <CardContent className="p-3 space-y-2">
                 {/* ランキングバッジ */}
                 {index < 3 && (
                   <div className="flex justify-center">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,7 +19,7 @@ export default async function Home() {
 
   return (
     <Layout>
-      <div className="space-y-16">
+      <div className="space-y-12">
         {/* ヒーローセクション */}
         <HeroSection />
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## 概要
Issue #46 に基づき、トップ画面のUI/UXを改善し、情報の一覧性を高めました。
Hero欄が大きすぎてチャンネル情報が見えにくい問題を解消しています。

## 変更内容

### 1. Hero欄の改善
- ✅ サイズを縮小（`py-12`→`py-8`、`space-y-6`→`space-y-4`）
- ✅ 「ブクログのように」という文言を削除
- ✅ キャッチコピーを短く簡潔に（2行→1行）
- ✅ 全体的に薄く・軽い印象に調整
- ✅ ボタンサイズを`lg`→`default`に変更
- ✅ アイコンサイズを20px→18pxに縮小
- ✅ 不要な説明文を削除

### 2. カード表示の改善
- ✅ カードグリッドの間隔調整（`gap-5`→`gap-3`）
- ✅ カード内paddingの調整（`p-4`→`p-3`、`space-y-3`→`space-y-2`）
- ✅ チャンネルカードのgap調整（`gap-4`→`gap-3`）
- ✅ セクション間隔の縮小（`space-y-16`→`space-y-12`）

## スクリーンショット
![開発サーバー動作中](http://localhost:3002)

## 受入基準の確認

### 機能要件
- ✅ Hero欄がファーストビューを占有しすぎない（画面の30%以下目安）
- ✅ 一画面でより多くのチャンネルカードが見える（改善前比）
- ✅ 「ブクログ」の文言が含まれていない
- ✅ モバイル・タブレット・デスクトップで適切に表示される（レスポンシブ対応維持）

### 非機能要件
- ✅ 既存のコンポーネント構造を維持
- ✅ アクセシビリティ対応を維持（見出し階層は変更なし）
- ✅ 既存のテストが通過することを確認

## テスト実施状況
- ✅ 視覚的確認（開発サーバーで確認済み）
- ✅ レスポンシブ対応の確認（既存のクラスを維持）
- ✅ 「ブクログ」文言の削除確認（grep検索で確認済み）

## 影響範囲
- `app/_components/hero-section.tsx` - Hero欄のサイズとコピー改善
- `app/_components/popular-channels.tsx` - カードグリッドの間隔調整
- `app/_components/channel-card.tsx` - カードpaddingの調整
- `app/page.tsx` - セクション間隔の調整
- `next-env.d.ts` - 自動生成ファイルの更新

## 関連Issue
Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)