### PR TITLE
fix: プロフィール編集画面のラベル色統一と海外選択肢追加

### DIFF
--- a/app/_components/profile/PrefectureSelect.tsx
+++ b/app/_components/profile/PrefectureSelect.tsx
@@ -28,7 +28,7 @@ export function PrefectureSelect({
 }: PrefectureSelectProps) {
   return (
     <div>
-      <Label htmlFor="prefecture" className="text-base font-semibold mb-2 block">
+      <Label htmlFor="prefecture" className="text-base font-semibold mb-2 block text-foreground">
         都道府県
       </Label>
       <Select value={value || 'unspecified'} onValueChange={onChange} disabled={disabled}>

--- a/app/_components/profile/ProfileEditForm.tsx
+++ b/app/_components/profile/ProfileEditForm.tsx
@@ -140,7 +140,7 @@ export function ProfileEditForm({ profile }: ProfileEditFormProps) {
 
         {/* 表示名 */}
         <div>
-          <Label htmlFor="displayName" className="text-base font-semibold mb-2 block">
+          <Label htmlFor="displayName" className="text-base font-semibold mb-2 block text-foreground">
             表示名
           </Label>
           <Input
@@ -162,7 +162,7 @@ export function ProfileEditForm({ profile }: ProfileEditFormProps) {
 
         {/* 自己紹介 */}
         <div>
-          <Label htmlFor="bio" className="text-base font-semibold mb-2 block">
+          <Label htmlFor="bio" className="text-base font-semibold mb-2 block text-foreground">
             自己紹介
           </Label>
           <Textarea
@@ -185,7 +185,7 @@ export function ProfileEditForm({ profile }: ProfileEditFormProps) {
 
         {/* 職業 */}
         <div>
-          <Label htmlFor="occupation" className="text-base font-semibold mb-2 block">
+          <Label htmlFor="occupation" className="text-base font-semibold mb-2 block text-foreground">
             職業
           </Label>
           <Input
@@ -207,7 +207,7 @@ export function ProfileEditForm({ profile }: ProfileEditFormProps) {
 
         {/* 性別 */}
         <div>
-          <Label htmlFor="gender" className="text-base font-semibold mb-2 block">
+          <Label htmlFor="gender" className="text-base font-semibold mb-2 block text-foreground">
             性別
           </Label>
           <Select value={gender} onValueChange={setGender} disabled={isSubmitting}>
@@ -229,7 +229,7 @@ export function ProfileEditForm({ profile }: ProfileEditFormProps) {
 
         {/* 生年月日 */}
         <div>
-          <Label htmlFor="birthDate" className="text-base font-semibold mb-2 block">
+          <Label htmlFor="birthDate" className="text-base font-semibold mb-2 block text-foreground">
             生年月日
           </Label>
           <Input
@@ -255,7 +255,7 @@ export function ProfileEditForm({ profile }: ProfileEditFormProps) {
 
         {/* ウェブサイトURL */}
         <div>
-          <Label htmlFor="websiteUrl" className="text-base font-semibold mb-2 block">
+          <Label htmlFor="websiteUrl" className="text-base font-semibold mb-2 block text-foreground">
             ウェブサイトURL
           </Label>
           <Input

--- a/lib/constants/prefectures.ts
+++ b/lib/constants/prefectures.ts
@@ -1,5 +1,5 @@
 /**
- * 日本の47都道府県リスト
+ * 日本の47都道府県と海外
  */
 export const PREFECTURES = [
   '北海道',
@@ -49,6 +49,7 @@ export const PREFECTURES = [
   '宮崎県',
   '鹿児島県',
   '沖縄県',
+  '海外',
 ] as const;
 
 export type Prefecture = (typeof PREFECTURES)[number];


### PR DESCRIPTION
## 📋 概要
プロフィール編集画面の項目名の文字色をレビュー入力画面と統一し、都道府県選択に海外の選択肢を追加しました。

## 🎯 背景・目的
- **UI/UXの一貫性**: 画面間でラベルの色を統一
- **視認性の向上**: レビュー入力画面と同じ見やすい色に
- **利便性の向上**: 海外在住ユーザーも都道府県を選択可能に

## 📝 変更内容

### 1. ラベルの文字色統一

#### 変更前
```tsx
<Label className="text-base font-semibold mb-2 block">
```

#### 変更後
```tsx
<Label className="text-base font-semibold mb-2 block text-foreground">
```

**統一した画面:**
- ✅ プロフィール編集画面（ProfileEditForm）
- ✅ 都道府県選択（PrefectureSelect）

**参照元:**
- レビュー入力画面（ReviewForm）のラベルスタイル

### 2. 都道府県選択に「海外」を追加

#### lib/constants/prefectures.ts
```typescript
export const PREFECTURES = [
  '北海道',
  '青森県',
  // ... 中略 ...
  '鹿児島県',
  '沖縄県',
  '海外', // ← 追加
] as const;
```

### ファイル変更サマリー
- `app/_components/profile/ProfileEditForm.tsx` - 全ラベルに text-foreground 追加
- `app/_components/profile/PrefectureSelect.tsx` - ラベルに text-foreground 追加
- `lib/constants/prefectures.ts` - 「海外」選択肢を追加

## 🎨 ビジュアル変更

### 変更箇所
- **表示名**のラベル
- **自己紹介**のラベル
- **職業**のラベル
- **性別**のラベル
- **生年月日**のラベル
- **都道府県**のラベル
- **ウェブサイトURL**のラベル

### 変更内容
- 文字色が統一され、視認性が向上
- レビュー入力画面と同じ見た目に

## 🧪 テスト

### テストケース
- [x] 正常系: ビルドが成功すること
- [x] 正常系: TypeScriptエラーがないこと
- [x] 正常系: 都道府県選択に「海外」が表示されること

### 動作確認済み環境
- [x] ローカル開発環境 (Node.js 20.x)
- [x] ビルド成功 (`npm run build`)

## 🚨 影響範囲

### 破壊的変更
- [x] なし

### UIへの影響
- [x] 改善あり
  - ラベルの視認性が向上
  - 画面間の一貫性が向上

### データへの影響
- [x] 影響なし
  - 既存のデータベース値に影響なし
  - 「海外」は新しい選択肢として追加されるのみ

## ✅ セルフチェックリスト

### コード品質
- [x] 変更が最小限で明確
- [x] 既存の動作に影響なし

### UI/UX
- [x] レビュー入力画面との一貫性を確保
- [x] 海外在住ユーザーの利便性を向上

### 品質保証
- [x] ビルド成功 (`npm run build`)

## 💬 補足事項

### 変更の意図
- ユーザーからのフィードバックに基づく改善
- プロフィール編集画面とレビュー入力画面のラベル色が異なっており、統一感がなかった
- 海外在住ユーザーから都道府県選択で海外を選べるようにしてほしいという要望

### text-foreground クラスについて
- Tailwind CSSのセマンティックカラートークン
- テーマに応じて適切な前景色（文字色）を自動的に適用
- ダークモードでも適切な色で表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)