### PR TITLE
fix: プロフィール編集ラベルの視認性改善

### DIFF
--- a/app/_components/profile/AvatarUploader.tsx
+++ b/app/_components/profile/AvatarUploader.tsx
@@ -88,7 +88,7 @@ export function AvatarUploader({
 
   return (
     <div>
-      <Label className="text-base font-semibold mb-2 block">
+      <Label className="text-base mb-2 block text-foreground">
         プロフィール画像
       </Label>
       <div className="flex items-center gap-4">

--- a/app/_components/profile/PrefectureSelect.tsx
+++ b/app/_components/profile/PrefectureSelect.tsx
@@ -28,7 +28,7 @@ export function PrefectureSelect({
 }: PrefectureSelectProps) {
   return (
     <div>
-      <Label htmlFor="prefecture" className="text-base font-semibold mb-2 block text-foreground">
+      <Label htmlFor="prefecture" className="text-base mb-2 block text-foreground">
         都道府県
       </Label>
       <Select value={value || 'unspecified'} onValueChange={onChange} disabled={disabled}>

--- a/app/_components/profile/ProfileEditForm.tsx
+++ b/app/_components/profile/ProfileEditForm.tsx
@@ -140,7 +140,7 @@ export function ProfileEditForm({ profile }: ProfileEditFormProps) {
 
         {/* 表示名 */}
         <div>
-          <Label htmlFor="displayName" className="text-base font-semibold mb-2 block text-foreground">
+          <Label htmlFor="displayName" className="text-base mb-2 block text-foreground">
             表示名
           </Label>
           <Input
@@ -162,7 +162,7 @@ export function ProfileEditForm({ profile }: ProfileEditFormProps) {
 
         {/* 自己紹介 */}
         <div>
-          <Label htmlFor="bio" className="text-base font-semibold mb-2 block text-foreground">
+          <Label htmlFor="bio" className="text-base mb-2 block text-foreground">
             自己紹介
           </Label>
           <Textarea
@@ -185,7 +185,7 @@ export function ProfileEditForm({ profile }: ProfileEditFormProps) {
 
         {/* 職業 */}
         <div>
-          <Label htmlFor="occupation" className="text-base font-semibold mb-2 block text-foreground">
+          <Label htmlFor="occupation" className="text-base mb-2 block text-foreground">
             職業
           </Label>
           <Input
@@ -207,7 +207,7 @@ export function ProfileEditForm({ profile }: ProfileEditFormProps) {
 
         {/* 性別 */}
         <div>
-          <Label htmlFor="gender" className="text-base font-semibold mb-2 block text-foreground">
+          <Label htmlFor="gender" className="text-base mb-2 block text-foreground">
             性別
           </Label>
           <Select value={gender} onValueChange={setGender} disabled={isSubmitting}>
@@ -229,7 +229,7 @@ export function ProfileEditForm({ profile }: ProfileEditFormProps) {
 
         {/* 生年月日 */}
         <div>
-          <Label htmlFor="birthDate" className="text-base font-semibold mb-2 block text-foreground">
+          <Label htmlFor="birthDate" className="text-base mb-2 block text-foreground">
             生年月日
           </Label>
           <Input
@@ -255,7 +255,7 @@ export function ProfileEditForm({ profile }: ProfileEditFormProps) {
 
         {/* ウェブサイトURL */}
         <div>
-          <Label htmlFor="websiteUrl" className="text-base font-semibold mb-2 block text-foreground">
+          <Label htmlFor="websiteUrl" className="text-base mb-2 block text-foreground">
             ウェブサイトURL
           </Label>
           <Input


### PR DESCRIPTION
## 概要
プロフィール編集画面のラベル視認性を改善しました。

## 背景
背景色に対してグレーテキストが見づらいという問題がありました。太字スタイル（font-semibold）を削除し、text-foregroundクラスのみを使用することで、シンプルかつ視認性の高いデザインに改善しました。

## 変更内容
- `AvatarUploader.tsx`: ラベルからfont-semiboldを削除
- `ProfileEditForm.tsx`: 全7つのラベル（表示名、自己紹介、職業、性別、生年月日、都道府県、ウェブサイトURL）からfont-semiboldを削除
- `PrefectureSelect.tsx`: ラベルからfont-semiboldを削除

すべてのラベルで`text-foreground`クラスを維持し、統一感のある見やすいUIを実現しています。

## テスト
- ✅ ビルド成功確認
- ✅ TypeScriptコンパイル成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)