### PR TITLE
fix: CI/E2E/Lighthouse workflowsに不足環境変数を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key
           YOUTUBE_API_KEY=dummy-youtube-api-key
           SUPABASE_SERVICE_ROLE_KEY=dummy-service-role-key
+          NEXTAUTH_SECRET=dummy-nextauth-secret-for-ci-build-only
+          NEXTAUTH_URL=http://localhost:3000
           EOF
 
       - name: Build Next.js application

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -44,6 +44,8 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+          NEXTAUTH_URL: http://localhost:3000
 
       - name: Run E2E tests
         run: npm run test:e2e
@@ -53,6 +55,8 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+          NEXTAUTH_URL: http://localhost:3000
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -40,6 +40,8 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+          NEXTAUTH_URL: http://localhost:3000
 
       - name: Run Lighthouse CI
         run: |


### PR DESCRIPTION
## 問題
全てのGitHub Actions workflowsが環境変数不足でビルド失敗していました。

### エラー内容
```
❌ Invalid environment variables:
Error [ZodError]: [
  {
    "expected": "string",
    "code": "invalid_type",
    "path": ["NEXTAUTH_SECRET"],
    "message": "Invalid input: expected string, received undefined"
  },
  {
    "expected": "string",
    "code": "invalid_type",
    "path": ["NEXTAUTH_URL"],
    "message": "Invalid input: expected string, received undefined"
  }
]
```

## 原因
アプリケーションのビルド時に`NEXTAUTH_SECRET`と`NEXTAUTH_URL`の環境変数が必須ですが、3つのworkflowsでこれらが設定されていませんでした。

## 修正内容

### 1. CI Workflow (`.github/workflows/ci.yml`)
ダミー環境変数ファイルに以下を追加:
```bash
NEXTAUTH_SECRET=dummy-nextauth-secret-for-ci-build-only
NEXTAUTH_URL=http://localhost:3000
```

### 2. E2E Tests Workflow (`.github/workflows/e2e-tests.yml`)  
ビルドステップの環境変数に追加:
```yaml
NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
NEXTAUTH_URL: http://localhost:3000
```

### 3. Lighthouse CI Workflow (`.github/workflows/lighthouse-ci.yml`)
ビルドステップの環境変数に追加:
```yaml
NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
NEXTAUTH_URL: http://localhost:3000
```

## テスト
- ✅ ローカルビルド成功確認
- ⏳ CIワークフローはこのPRでテストされます

## 影響範囲
- CI Workflow
- E2E Tests Workflow  
- Lighthouse CI Workflow

全てのworkflowsで正常にビルドが完了するようになります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)