### PR TITLE
fix: Resolve all TypeScript type errors in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,6 @@ jobs:
 
       - name: Run TypeScript type check
         run: npx tsc --noEmit
-        continue-on-error: true # TODO: Fix type errors in separate PR
 
   test:
     name: Unit Tests

--- a/__tests__/e2e/review-submission.spec.ts
+++ b/__tests__/e2e/review-submission.spec.ts
@@ -1,116 +1,118 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test.describe('Review Submission', () => {
+test.describe("Review Submission", () => {
   test.beforeEach(async () => {
     // Note: This test requires a logged-in user
     // In a real scenario, you would need to implement login flow or use stored auth state
   });
 
-  test('should display review form for authenticated users', async ({ page }) => {
+  test("should display review form for authenticated users", async ({
+    page,
+  }) => {
     // Navigate to a channel detail page
     // Note: Replace with actual channel ID from your test data
-    await page.goto('/channels/UC_test_channel_id');
+    await page.goto("/channels/UC_test_channel_id");
 
     // Check if review form is visible
-    await expect(page.getByText('レビューを投稿')).toBeVisible();
-    await expect(page.getByRole('radiogroup', { name: '評価' })).toBeVisible();
+    await expect(page.getByText("レビューを投稿")).toBeVisible();
+    await expect(page.getByRole("radiogroup", { name: "評価" })).toBeVisible();
   });
 
-  test('should validate review form inputs', async ({ page }) => {
-    await page.goto('/channels/UC_test_channel_id');
+  test("should validate review form inputs", async ({ page }) => {
+    await page.goto("/channels/UC_test_channel_id");
 
     // Try to submit without rating
-    const submitButton = page.getByRole('button', { name: 'レビューを投稿' });
+    const submitButton = page.getByRole("button", { name: "レビューを投稿" });
     await expect(submitButton).toBeDisabled();
 
     // Select rating
-    const stars = page.getByRole('radio', { name: '5つ星' });
+    const stars = page.getByRole("radio", { name: "5つ星" });
     await stars.click();
 
     // Try to submit without content (should still be disabled)
     await expect(submitButton).toBeDisabled();
 
     // Add content less than 50 characters
-    const contentTextarea = page.getByRole('textbox', { name: /レビュー本文/ });
-    await contentTextarea.fill('Short content');
+    const contentTextarea = page.getByRole("textbox", { name: /レビュー本文/ });
+    await contentTextarea.fill("Short content");
 
     // Submit button should still be disabled
     await expect(submitButton).toBeDisabled();
 
     // Add content with at least 50 characters
     await contentTextarea.fill(
-      'This is a detailed review with at least fifty characters to meet the minimum requirement.'
+      "This is a detailed review with at least fifty characters to meet the minimum requirement."
     );
 
     // Submit button should now be enabled
     await expect(submitButton).toBeEnabled();
   });
 
-  test('should submit review successfully', async ({ page }) => {
-    await page.goto('/channels/UC_test_channel_id');
+  test("should submit review successfully", async ({ page }) => {
+    await page.goto("/channels/UC_test_channel_id");
 
     // Fill in the review form
-    const ratingButton = page.getByRole('radio', { name: '5つ星' });
+    const ratingButton = page.getByRole("radio", { name: "5つ星" });
     await ratingButton.click();
 
-    const titleInput = page.getByLabelText('タイトル（オプション）');
-    await titleInput.fill('Great channel!');
+    const titleInput = page.getByLabel("タイトル（オプション）");
+    await titleInput.fill("Great channel!");
 
-    const contentTextarea = page.getByLabelText(/レビュー本文/);
+    const contentTextarea = page.getByLabel(/レビュー本文/);
     await contentTextarea.fill(
-      'This is a great channel with amazing content. I highly recommend it to everyone interested in the topic. The host is knowledgeable and engaging.'
+      "This is a great channel with amazing content. I highly recommend it to everyone interested in the topic. The host is knowledgeable and engaging."
     );
 
     // Submit the form
-    const submitButton = page.getByRole('button', { name: 'レビューを投稿' });
+    const submitButton = page.getByRole("button", { name: "レビューを投稿" });
     await submitButton.click();
 
     // Wait for success toast
-    await expect(page.getByText('レビューを投稿しました')).toBeVisible();
+    await expect(page.getByText("レビューを投稿しました")).toBeVisible();
 
     // Form should be reset
-    await expect(titleInput).toHaveValue('');
-    await expect(contentTextarea).toHaveValue('');
+    await expect(titleInput).toHaveValue("");
+    await expect(contentTextarea).toHaveValue("");
   });
 
-  test('should show error for duplicate review', async ({ page }) => {
+  test("should show error for duplicate review", async ({ page }) => {
     // This test assumes the user has already submitted a review for this channel
-    await page.goto('/channels/UC_test_channel_id');
+    await page.goto("/channels/UC_test_channel_id");
 
     // Fill in the review form
-    await page.getByRole('radio', { name: '5つ星' }).click();
+    await page.getByRole("radio", { name: "5つ星" }).click();
     await page
-      .getByLabelText(/レビュー本文/)
+      .getByLabel(/レビュー本文/)
       .fill(
-        'This is another review attempt to test duplicate detection with enough characters.'
+        "This is another review attempt to test duplicate detection with enough characters."
       );
 
     // Submit the form
-    await page.getByRole('button', { name: 'レビューを投稿' }).click();
+    await page.getByRole("button", { name: "レビューを投稿" }).click();
 
     // Wait for error toast
     await expect(
-      page.getByText('このチャンネルにはすでにレビューを投稿しています')
+      page.getByText("このチャンネルにはすでにレビューを投稿しています")
     ).toBeVisible();
   });
 
-  test('should show character count feedback', async ({ page }) => {
-    await page.goto('/channels/UC_test_channel_id');
+  test("should show character count feedback", async ({ page }) => {
+    await page.goto("/channels/UC_test_channel_id");
 
-    const contentTextarea = page.getByLabelText(/レビュー本文/);
+    const contentTextarea = page.getByLabel(/レビュー本文/);
 
     // Check initial character count
-    await expect(page.getByText('0 / 2000文字')).toBeVisible();
+    await expect(page.getByText("0 / 2000文字")).toBeVisible();
 
     // Type some content
-    await contentTextarea.fill('Short');
+    await contentTextarea.fill("Short");
 
     // Check updated character count with "あとX文字必要" message
     await expect(page.getByText(/あと45文字必要/)).toBeVisible();
 
     // Fill with 50+ characters
     await contentTextarea.fill(
-      'This is a detailed review with at least fifty characters.'
+      "This is a detailed review with at least fifty characters."
     );
 
     // Error message should disappear

--- a/app/_actions/__tests__/review-helpful.test.ts
+++ b/app/_actions/__tests__/review-helpful.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { toggleHelpfulAction } from "../review";
+import type { User } from "@supabase/supabase-js";
 
 // Supabase と auth をモック
 vi.mock("@/lib/supabase/server", () => ({
@@ -22,14 +23,23 @@ describe("toggleHelpfulAction", () => {
     const result = await toggleHelpfulAction("test-review-id");
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe("ログインが必要です");
+    if (!result.success) {
+      expect(result.error).toBe("ログインが必要です");
+    }
   });
 
   it.skip("should add vote when not voted yet", async () => {
     const { getUser } = await import("@/lib/auth");
     const { createClient } = await import("@/lib/supabase/server");
 
-    const mockUser = { id: "user-id", email: "test@example.com" };
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
     vi.mocked(getUser).mockResolvedValue(mockUser);
 
     const mockSupabase = {
@@ -53,14 +63,6 @@ describe("toggleHelpfulAction", () => {
                 error: null,
               })
             ),
-            select: vi.fn(() => ({
-              eq: vi.fn(() =>
-                Promise.resolve({
-                  count: 1,
-                  error: null,
-                })
-              ),
-            })),
           };
         } else if (table === "reviews") {
           return {
@@ -90,7 +92,7 @@ describe("toggleHelpfulAction", () => {
     };
 
     vi.mocked(createClient).mockResolvedValue(
-      mockSupabase as unknown as ReturnType<typeof createClient>
+      mockSupabase as unknown as Awaited<ReturnType<typeof createClient>>
     );
 
     const result = await toggleHelpfulAction("test-review-id");
@@ -105,7 +107,14 @@ describe("toggleHelpfulAction", () => {
     const { getUser } = await import("@/lib/auth");
     const { createClient } = await import("@/lib/supabase/server");
 
-    const mockUser = { id: "user-id", email: "test@example.com" };
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
     vi.mocked(getUser).mockResolvedValue(mockUser);
 
     const mockSupabase = {
@@ -168,7 +177,7 @@ describe("toggleHelpfulAction", () => {
     };
 
     vi.mocked(createClient).mockResolvedValue(
-      mockSupabase as unknown as ReturnType<typeof createClient>
+      mockSupabase as unknown as Awaited<ReturnType<typeof createClient>>
     );
 
     const result = await toggleHelpfulAction("test-review-id");
@@ -183,7 +192,14 @@ describe("toggleHelpfulAction", () => {
     const { getUser } = await import("@/lib/auth");
     const { createClient } = await import("@/lib/supabase/server");
 
-    const mockUser = { id: "user-id", email: "test@example.com" };
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
     vi.mocked(getUser).mockResolvedValue(mockUser);
 
     const mockSupabase = {
@@ -202,12 +218,14 @@ describe("toggleHelpfulAction", () => {
     };
 
     vi.mocked(createClient).mockResolvedValue(
-      mockSupabase as unknown as ReturnType<typeof createClient>
+      mockSupabase as unknown as Awaited<ReturnType<typeof createClient>>
     );
 
     const result = await toggleHelpfulAction("test-review-id");
 
     expect(result.success).toBe(false);
-    expect(result.error).toBe("投票状態の確認に失敗しました");
+    if (!result.success) {
+      expect(result.error).toBe("投票状態の確認に失敗しました");
+    }
   });
 });

--- a/app/api/auth/magic-link/__tests__/route.test.ts
+++ b/app/api/auth/magic-link/__tests__/route.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { POST } from '../route';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { POST } from "../route";
+import type { NextRequest } from "next/server";
 
 // Mock Supabase client
-vi.mock('@/lib/supabase/server', () => ({
+vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(() => ({
     auth: {
       signInWithOtp: vi.fn().mockResolvedValue({ error: null }),
@@ -13,21 +14,23 @@ vi.mock('@/lib/supabase/server', () => ({
 // Mock Next.js Request
 class MockNextRequest extends Request {
   constructor(body: any) {
-    super('http://localhost:3000/api/auth/magic-link', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    super("http://localhost:3000/api/auth/magic-link", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     });
   }
 }
 
-describe('POST /api/auth/magic-link', () => {
+describe("POST /api/auth/magic-link", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('有効なメールアドレスでMagic Linkを送信', async () => {
-    const request = new MockNextRequest({ email: 'test@example.com' });
+  it("有効なメールアドレスでMagic Linkを送信", async () => {
+    const request = new MockNextRequest({
+      email: "test@example.com",
+    }) as unknown as NextRequest;
     const response = await POST(request);
     const data = await response.json();
 
@@ -35,18 +38,22 @@ describe('POST /api/auth/magic-link', () => {
     expect(data.success).toBe(true);
   });
 
-  it('無効なメールアドレスでエラー', async () => {
-    const request = new MockNextRequest({ email: 'invalid' });
+  it("無効なメールアドレスでエラー", async () => {
+    const request = new MockNextRequest({
+      email: "invalid",
+    }) as unknown as NextRequest;
     const response = await POST(request);
     const data = await response.json();
 
     expect(response.status).toBe(400);
     expect(data.error).toBeDefined();
-    expect(data.error).toContain('有効なメールアドレスを入力してください');
+    expect(data.error).toContain("有効なメールアドレスを入力してください");
   });
 
-  it('メールアドレスが空の場合エラー', async () => {
-    const request = new MockNextRequest({ email: '' });
+  it("メールアドレスが空の場合エラー", async () => {
+    const request = new MockNextRequest({
+      email: "",
+    }) as unknown as NextRequest;
     const response = await POST(request);
     const data = await response.json();
 
@@ -54,8 +61,8 @@ describe('POST /api/auth/magic-link', () => {
     expect(data.error).toBeDefined();
   });
 
-  it('bodyが空の場合エラー', async () => {
-    const request = new MockNextRequest({});
+  it("bodyが空の場合エラー", async () => {
+    const request = new MockNextRequest({}) as unknown as NextRequest;
     const response = await POST(request);
     const data = await response.json();
 

--- a/lib/youtube/__tests__/api.test.ts
+++ b/lib/youtube/__tests__/api.test.ts
@@ -1,44 +1,44 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { searchChannels, getChannelDetails } from '../api';
-import { YouTubeErrorCode } from '../types';
-import * as cache from '../cache';
-import * as rateLimiter from '../rate-limiter';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { searchChannels, getChannelDetails } from "../api";
+import { YouTubeErrorCode } from "../types";
+import * as cache from "../cache";
+import * as rateLimiter from "../rate-limiter";
 
 // Mock modules
-vi.mock('../cache');
-vi.mock('../rate-limiter');
+vi.mock("../cache");
+vi.mock("../rate-limiter");
 
 // Mock env
-vi.mock('@/lib/env', () => ({
+vi.mock("@/lib/env", () => ({
   env: {
-    YOUTUBE_API_KEY: 'test-api-key',
+    YOUTUBE_API_KEY: "test-api-key",
   },
 }));
 
 // Mock fetch
 global.fetch = vi.fn();
 
-describe('YouTube API Client', () => {
+describe("YouTube API Client", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  describe('searchChannels', () => {
-    it('should return cached data when available', async () => {
+  describe("searchChannels", () => {
+    it("should return cached data when available", async () => {
       // Arrange
-      const query = 'test channel';
+      const query = "test channel";
       const maxResults = 10;
       const cachedResults = [
         {
-          youtubeChannelId: 'UC123',
-          title: 'Test Channel',
-          description: 'Test description',
-          thumbnailUrl: 'https://example.com/thumb.jpg',
+          youtubeChannelId: "UC123",
+          title: "Test Channel",
+          description: "Test description",
+          thumbnailUrl: "https://example.com/thumb.jpg",
         },
       ];
 
       vi.mocked(cache.generateCacheKey).mockReturnValue(
-        'youtube:search:abc123'
+        "youtube:search:abc123"
       );
       vi.mocked(cache.getCachedData).mockResolvedValue(cachedResults);
 
@@ -52,21 +52,25 @@ describe('YouTube API Client', () => {
       expect(fetch).not.toHaveBeenCalled();
     });
 
-    it('should fetch from API when cache misses', async () => {
+    it("should fetch from API when cache misses", async () => {
       // Arrange
-      const query = 'test channel';
+      const query = "test channel";
       const maxResults = 10;
       const apiResponse = {
         items: [
           {
-            id: { channelId: 'UC123' },
+            id: { channelId: "UC123" },
             snippet: {
-              title: 'Test Channel',
-              description: 'Test description',
+              title: "Test Channel",
+              description: "Test description",
               thumbnails: {
-                high: { url: 'https://example.com/thumb.jpg', width: 800, height: 800 },
-                medium: { url: '', width: 0, height: 0 },
-                default: { url: '', width: 0, height: 0 },
+                high: {
+                  url: "https://example.com/thumb.jpg",
+                  width: 800,
+                  height: 800,
+                },
+                medium: { url: "", width: 0, height: 0 },
+                default: { url: "", width: 0, height: 0 },
               },
             },
           },
@@ -74,7 +78,7 @@ describe('YouTube API Client', () => {
       };
 
       vi.mocked(cache.generateCacheKey).mockReturnValue(
-        'youtube:search:abc123'
+        "youtube:search:abc123"
       );
       vi.mocked(cache.getCachedData).mockResolvedValue(null);
       vi.mocked(rateLimiter.youtubeRateLimiter.checkQuota).mockResolvedValue(
@@ -91,17 +95,17 @@ describe('YouTube API Client', () => {
 
       // Assert
       expect(result).toHaveLength(1);
-      expect(result[0].youtubeChannelId).toBe('UC123');
-      expect(result[0].title).toBe('Test Channel');
+      expect(result[0]?.youtubeChannelId).toBe("UC123");
+      expect(result[0]?.title).toBe("Test Channel");
       expect(rateLimiter.youtubeRateLimiter.checkQuota).toHaveBeenCalledWith(
-        'search'
+        "search"
       );
       expect(cache.setCachedData).toHaveBeenCalled();
     });
 
-    it('should throw RATE_LIMIT error on 403 quota response', async () => {
+    it("should throw RATE_LIMIT error on 403 quota response", async () => {
       // Arrange
-      const query = 'test';
+      const query = "test";
       const maxResults = 10;
 
       vi.mocked(cache.getCachedData).mockResolvedValue(null);
@@ -112,22 +116,22 @@ describe('YouTube API Client', () => {
         ok: false,
         status: 403,
         json: async () => ({
-          error: { message: 'quotaExceeded' },
+          error: { message: "quotaExceeded" },
         }),
       } as Response);
 
       // Act & Assert
       try {
         await searchChannels(query, maxResults);
-        expect.fail('Should have thrown error');
+        expect.fail("Should have thrown error");
       } catch (error) {
         expect((error as any).code).toBe(YouTubeErrorCode.RATE_LIMIT);
       }
     });
 
-    it('should throw NOT_FOUND error on 404 response', async () => {
+    it("should throw NOT_FOUND error on 404 response", async () => {
       // Arrange
-      const query = 'nonexistent';
+      const query = "nonexistent";
       const maxResults = 10;
 
       vi.mocked(cache.getCachedData).mockResolvedValue(null);
@@ -143,35 +147,35 @@ describe('YouTube API Client', () => {
       // Act & Assert
       try {
         await searchChannels(query, maxResults);
-        expect.fail('Should have thrown error');
+        expect.fail("Should have thrown error");
       } catch (error) {
         expect((error as any).code).toBe(YouTubeErrorCode.NOT_FOUND);
       }
     });
 
-    it('should handle network errors', async () => {
+    it("should handle network errors", async () => {
       // Arrange
-      const query = 'test';
+      const query = "test";
       const maxResults = 10;
 
       vi.mocked(cache.getCachedData).mockResolvedValue(null);
       vi.mocked(rateLimiter.youtubeRateLimiter.checkQuota).mockResolvedValue(
         undefined
       );
-      vi.mocked(fetch).mockRejectedValue(new Error('Network error'));
+      vi.mocked(fetch).mockRejectedValue(new Error("Network error"));
 
       // Act & Assert
       try {
         await searchChannels(query, maxResults);
-        expect.fail('Should have thrown error');
+        expect.fail("Should have thrown error");
       } catch (error) {
         expect((error as any).code).toBe(YouTubeErrorCode.NETWORK_ERROR);
       }
     });
 
-    it('should throw INVALID_API_KEY error on 403 non-quota response', async () => {
+    it("should throw INVALID_API_KEY error on 403 non-quota response", async () => {
       // Arrange
-      const query = 'test';
+      const query = "test";
       const maxResults = 10;
 
       vi.mocked(cache.getCachedData).mockResolvedValue(null);
@@ -182,37 +186,37 @@ describe('YouTube API Client', () => {
         ok: false,
         status: 403,
         json: async () => ({
-          error: { message: 'Invalid API key' },
+          error: { message: "Invalid API key" },
         }),
       } as Response);
 
       // Act & Assert
       try {
         await searchChannels(query, maxResults);
-        expect.fail('Should have thrown error');
+        expect.fail("Should have thrown error");
       } catch (error) {
         expect((error as any).code).toBe(YouTubeErrorCode.INVALID_API_KEY);
       }
     });
   });
 
-  describe('getChannelDetails', () => {
-    it('should return cached data when available', async () => {
+  describe("getChannelDetails", () => {
+    it("should return cached data when available", async () => {
       // Arrange
-      const youtubeChannelId = 'UC123';
+      const youtubeChannelId = "UC123";
       const cachedDetails = {
         youtubeChannelId,
-        title: 'Test Channel',
-        description: 'Test description',
-        customUrl: '@testchannel',
-        thumbnailUrl: 'https://example.com/thumb.jpg',
+        title: "Test Channel",
+        description: "Test description",
+        customUrl: "@testchannel",
+        thumbnailUrl: "https://example.com/thumb.jpg",
         subscriberCount: 1000,
         videoCount: 50,
         viewCount: 10000,
       };
 
       vi.mocked(cache.generateCacheKey).mockReturnValue(
-        'youtube:details:def456'
+        "youtube:details:def456"
       );
       vi.mocked(cache.getCachedData).mockResolvedValue(cachedDetails);
 
@@ -225,27 +229,31 @@ describe('YouTube API Client', () => {
       expect(fetch).not.toHaveBeenCalled();
     });
 
-    it('should fetch from API when cache misses', async () => {
+    it("should fetch from API when cache misses", async () => {
       // Arrange
-      const youtubeChannelId = 'UC123';
+      const youtubeChannelId = "UC123";
       const apiResponse = {
         items: [
           {
-            id: 'UC123',
+            id: "UC123",
             snippet: {
-              title: 'Test Channel',
-              description: 'Test description',
-              customUrl: '@testchannel',
+              title: "Test Channel",
+              description: "Test description",
+              customUrl: "@testchannel",
               thumbnails: {
-                high: { url: 'https://example.com/thumb.jpg', width: 800, height: 800 },
-                medium: { url: '', width: 0, height: 0 },
-                default: { url: '', width: 0, height: 0 },
+                high: {
+                  url: "https://example.com/thumb.jpg",
+                  width: 800,
+                  height: 800,
+                },
+                medium: { url: "", width: 0, height: 0 },
+                default: { url: "", width: 0, height: 0 },
               },
             },
             statistics: {
-              subscriberCount: '1000',
-              videoCount: '50',
-              viewCount: '10000',
+              subscriberCount: "1000",
+              videoCount: "50",
+              viewCount: "10000",
             },
           },
         ],
@@ -265,19 +273,19 @@ describe('YouTube API Client', () => {
       const result = await getChannelDetails(youtubeChannelId);
 
       // Assert
-      expect(result.youtubeChannelId).toBe('UC123');
+      expect(result.youtubeChannelId).toBe("UC123");
       expect(result.subscriberCount).toBe(1000);
       expect(result.videoCount).toBe(50);
       expect(result.viewCount).toBe(10000);
       expect(rateLimiter.youtubeRateLimiter.checkQuota).toHaveBeenCalledWith(
-        'details'
+        "details"
       );
       expect(cache.setCachedData).toHaveBeenCalled();
     });
 
-    it('should throw NOT_FOUND when channel does not exist', async () => {
+    it("should throw NOT_FOUND when channel does not exist", async () => {
       // Arrange
-      const youtubeChannelId = 'UCnonexistent';
+      const youtubeChannelId = "UCnonexistent";
 
       vi.mocked(cache.getCachedData).mockResolvedValue(null);
       vi.mocked(rateLimiter.youtubeRateLimiter.checkQuota).mockResolvedValue(
@@ -291,7 +299,7 @@ describe('YouTube API Client', () => {
       // Act & Assert
       try {
         await getChannelDetails(youtubeChannelId);
-        expect.fail('Should have thrown error');
+        expect.fail("Should have thrown error");
       } catch (error) {
         expect((error as any).code).toBe(YouTubeErrorCode.NOT_FOUND);
       }

--- a/tests/e2e/review-helpful.spec.ts
+++ b/tests/e2e/review-helpful.spec.ts
@@ -1,12 +1,14 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from "@playwright/test";
 
-test.describe('Review Helpful Button', () => {
+test.describe("Review Helpful Button", () => {
   test.beforeEach(async ({ page }) => {
     // テスト用のチャンネル詳細ページに移動（HikakinTV）
-    await page.goto('/channels/UCZf__ehlCEBPop-_sldpBUQ', { waitUntil: 'networkidle' });
+    await page.goto("/channels/UCZf__ehlCEBPop-_sldpBUQ", {
+      waitUntil: "networkidle",
+    });
   });
 
-  test.skip('should show helpful button on reviews', async ({ page }) => {
+  test.skip("should show helpful button on reviews", async ({ page }) => {
     // TODO: テストデータ（レビュー）が存在しない場合があるためスキップ
     // レビューカードを取得
     const reviewCard = page.locator('[data-testid="review-card"]').first();
@@ -16,45 +18,50 @@ test.describe('Review Helpful Button', () => {
     await expect(helpfulButton).toBeVisible({ timeout: 10000 });
 
     // ボタンに「参考になった」テキストが含まれることを確認
-    await expect(helpfulButton).toContainText('参考になった');
+    await expect(helpfulButton).toContainText("参考になった");
   });
 
-  test.skip('should require login to vote', async ({ page }) => {
+  test.skip("should require login to vote", async ({ page }) => {
     // 未ログイン状態で「参考になった」ボタンをクリック
-    const helpfulButton = page.locator('[data-testid="helpful-button"]').first();
+    const helpfulButton = page
+      .locator('[data-testid="helpful-button"]')
+      .first();
     await helpfulButton.click();
 
     // トーストメッセージが表示されることを確認
     // Note: トーストの実装によって調整が必要
-    const toast = page.locator('text=ログインが必要です').first();
+    const toast = page.locator("text=ログインが必要です").first();
     await expect(toast).toBeVisible({ timeout: 5000 });
   });
 
-  test.describe('Logged in user', () => {
+  test.describe("Logged in user", () => {
     test.beforeEach(async ({ page }) => {
       // テスト用ユーザーでログイン
       // Note: 実際の認証フローに合わせて調整が必要
-      await page.goto('/login');
-      await page.fill('input[type="email"]', 'test1@example.com');
+      await page.goto("/login");
+      await page.fill('input[type="email"]', "test1@example.com");
       await page.click('button[type="submit"]');
 
       // Magic Linkのシミュレーション（開発環境）
       // または、認証状態を直接設定するヘルパー関数を使用
 
       // チャンネル詳細ページに戻る
-      await page.goto('/channels/UCZf__ehlCEBPop-_sldpBUQ');
-      await page.waitForLoadState('networkidle');
+      await page.goto("/channels/UCZf__ehlCEBPop-_sldpBUQ");
+      await page.waitForLoadState("networkidle");
     });
 
-    test.skip('should toggle helpful vote', async ({ page }) => {
+    test.skip("should toggle helpful vote", async ({ page }) => {
       // TODO: テストデータ（レビュー）が存在しない場合があるためスキップ
       const reviewCard = page.locator('[data-testid="review-card"]').first();
-      const helpfulButton = reviewCard.locator('[data-testid="helpful-button"]');
+      const helpfulButton = reviewCard.locator(
+        '[data-testid="helpful-button"]'
+      );
       const helpfulCount = reviewCard.locator('[data-testid="helpful-count"]');
 
       // 初期状態の投票数を取得
-      const initialCountText = await helpfulCount.textContent().catch(() => '(0)');
-      const initialCount = parseInt(initialCountText.match(/\d+/)?.[0] || '0');
+      const initialCountText =
+        (await helpfulCount.textContent().catch(() => "(0)")) || "(0)";
+      const initialCount = parseInt(initialCountText.match(/\d+/)?.[0] || "0");
 
       // ボタンをクリックして投票
       await helpfulButton.click();
@@ -63,7 +70,7 @@ test.describe('Review Helpful Button', () => {
       await expect(helpfulCount).toContainText(`(${initialCount + 1})`);
 
       // ボタンの状態が変わることを確認（アクティブ状態）
-      await expect(helpfulButton).toHaveAttribute('data-state', 'active');
+      await expect(helpfulButton).toHaveAttribute("data-state", "active");
 
       // もう一度クリックして投票を取り消し
       await helpfulButton.click();
@@ -72,10 +79,12 @@ test.describe('Review Helpful Button', () => {
       await expect(helpfulCount).toContainText(`(${initialCount})`);
     });
 
-    test.skip('should prevent duplicate votes', async ({ page }) => {
+    test.skip("should prevent duplicate votes", async ({ page }) => {
       // TODO: テストデータ（レビュー）が存在しない場合があるためスキップ
       const reviewCard = page.locator('[data-testid="review-card"]').first();
-      const helpfulButton = reviewCard.locator('[data-testid="helpful-button"]');
+      const helpfulButton = reviewCard.locator(
+        '[data-testid="helpful-button"]'
+      );
       const helpfulCount = reviewCard.locator('[data-testid="helpful-count"]');
 
       // 投票
@@ -86,27 +95,37 @@ test.describe('Review Helpful Button', () => {
 
       // ページをリロード
       await page.reload();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState("networkidle");
 
       // 投票状態が保持されていることを確認
-      const reviewCardAfterReload = page.locator('[data-testid="review-card"]').first();
-      const helpfulCountAfterReload = reviewCardAfterReload.locator('[data-testid="helpful-count"]');
+      const reviewCardAfterReload = page
+        .locator('[data-testid="review-card"]')
+        .first();
+      const helpfulCountAfterReload = reviewCardAfterReload.locator(
+        '[data-testid="helpful-count"]'
+      );
 
-      await expect(helpfulCountAfterReload).toContainText(countAfterFirstClick || '(1)');
+      await expect(helpfulCountAfterReload).toContainText(
+        countAfterFirstClick || "(1)"
+      );
     });
 
-    test('should show correct count for multiple votes', async ({ page }) => {
+    test("should show correct count for multiple votes", async ({ page }) => {
       // 複数のレビューカードを取得
       const reviewCards = page.locator('[data-testid="review-card"]');
       const count = await reviewCards.count();
 
       if (count >= 2) {
         // 1つ目のレビューに投票
-        const firstButton = reviewCards.nth(0).locator('[data-testid="helpful-button"]');
+        const firstButton = reviewCards
+          .nth(0)
+          .locator('[data-testid="helpful-button"]');
         await firstButton.click();
 
         // 2つ目のレビューに投票
-        const secondButton = reviewCards.nth(1).locator('[data-testid="helpful-button"]');
+        const secondButton = reviewCards
+          .nth(1)
+          .locator('[data-testid="helpful-button"]');
         await secondButton.click();
 
         // 両方のボタンがアクティブ状態になることを確認
@@ -117,7 +136,7 @@ test.describe('Review Helpful Button', () => {
     });
   });
 
-  test.skip('should display helpful count correctly', async ({ page }) => {
+  test.skip("should display helpful count correctly", async ({ page }) => {
     // TODO: テストデータ（レビュー）が存在しない場合があるためスキップ
     const reviewCard = page.locator('[data-testid="review-card"]').first();
     const helpfulButton = reviewCard.locator('[data-testid="helpful-button"]');
@@ -129,20 +148,22 @@ test.describe('Review Helpful Button', () => {
     const buttonText = await helpfulButton.textContent();
 
     // ボタンテキストに「参考になった」が含まれることを確認
-    expect(buttonText).toContain('参考になった');
+    expect(buttonText).toContain("参考になった");
 
     // 投票数がある場合は括弧付きで表示されることを確認
-    if (buttonText?.includes('(')) {
+    if (buttonText?.includes("(")) {
       expect(buttonText).toMatch(/\(\d+\)/);
     }
   });
 
-  test.skip('should have accessible button attributes', async ({ page }) => {
+  test.skip("should have accessible button attributes", async ({ page }) => {
     // TODO: テストデータ（レビュー）が存在しない場合があるためスキップ
-    const helpfulButton = page.locator('[data-testid="helpful-button"]').first();
+    const helpfulButton = page
+      .locator('[data-testid="helpful-button"]')
+      .first();
 
     // aria-label属性が設定されていることを確認
-    const ariaLabel = await helpfulButton.getAttribute('aria-label');
+    const ariaLabel = await helpfulButton.getAttribute("aria-label");
     expect(ariaLabel).toBeTruthy();
     expect(ariaLabel).toMatch(/参考になった/);
   });


### PR DESCRIPTION
## 概要

Issue #99 の残タスクとして、全ての TypeScript 型エラーを修正し、CI の TypeCheck から `continue-on-error` を削除しました。

## 修正内容

### 1. Playwright テストの型エラー修正 (5件)
- `getByLabelText` → `getByLabel` に変更（Playwright API の正しいメソッド名）
- Optional chaining を追加して null チェック

### 2. review-helpful.test.ts の型エラー修正 (10件)
- `User` 型の import と完全なモックオブジェクトの作成
- `ApiResponse` の型ガードを追加
- `createClient` の戻り値型を `Awaited<ReturnType<typeof createClient>>` に修正
- 重複していた `select` プロパティを削除

### 3. magic-link route.test.ts の型エラー修正 (4件)
- `MockNextRequest` を `NextRequest` 型にキャスト

### 4. YouTube API テストの型エラー修正 (2件)
- 配列アクセスに optional chaining を追加 (`result[0]?.property`)

### 5. CI 設定の更新
- `.github/workflows/ci.yml` から TypeCheck の `continue-on-error: true` を削除
- 型エラーがある場合、PR マージをブロックするように変更

## テスト結果

### TypeScript チェック
\`\`\`bash
npx tsc --noEmit
# ✅ No errors
\`\`\`

### ユニットテスト
\`\`\`
Test Files  6 passed (6)
Tests  51 passed | 2 skipped (53)
\`\`\`

## 影響範囲

- テストファイルのみの修正
- 本番コードには影響なし
- CI で型エラーが検出されるようになる（品質向上）

## レビューポイント

- 型ガードの使用方法は適切か
- モック型定義は十分か
- Optional chaining の使用は適切か

---

Closes #99 残タスク（TypeScript 型エラー修正）