### PR TITLE
test: サーバーアクションのテストカバレッジ拡充 (#102)

### DIFF
--- a/app/_actions/__tests__/category.test.ts
+++ b/app/_actions/__tests__/category.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  getCategories,
+  getChannelsByCategory,
+  type CategoryWithCount,
+  type CategoryChannel,
+} from "../category";
+
+// Supabase client mock
+const mockSupabase = {
+  from: vi.fn(),
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve(mockSupabase)),
+}));
+
+vi.mock("@/lib/constants/categories", async () => {
+  const actual = await vi.importActual("@/lib/constants/categories");
+  return {
+    ...actual,
+    CATEGORIES: [
+      { slug: "tech", name: "テクノロジー", icon: "💻" },
+      { slug: "gaming", name: "ゲーム", icon: "🎮" },
+    ],
+    getCategoryBySlug: (slug: string) => {
+      if (slug === "tech")
+        return { slug: "tech", name: "テクノロジー", icon: "💻" };
+      if (slug === "gaming")
+        return { slug: "gaming", name: "ゲーム", icon: "🎮" };
+      return null;
+    },
+  };
+});
+
+describe("getCategories", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return all categories with channel counts and top channels", async () => {
+    // Arrange
+    const mockFrom = vi.fn();
+    mockSupabase.from = mockFrom;
+
+    // Mock channel count query
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "channels") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() =>
+              Promise.resolve({
+                count: 10,
+                error: null,
+              })
+            ),
+          })),
+        };
+      }
+      // Mock top channels query
+      if (table === "channels_with_stats") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn(() => ({
+                limit: vi.fn(() =>
+                  Promise.resolve({
+                    data: [
+                      {
+                        id: "ch1",
+                        youtube_channel_id: "UC123",
+                        thumbnail_url: "https://example.com/thumb.jpg",
+                      },
+                    ],
+                    error: null,
+                  })
+                ),
+              })),
+            })),
+          })),
+        };
+      }
+      return {};
+    });
+
+    // Act
+    const result = await getCategories();
+
+    // Assert
+    expect(result).toBeDefined();
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.length).toBeGreaterThan(0);
+
+    const firstCategory = result[0] as CategoryWithCount;
+    expect(firstCategory).toHaveProperty("slug");
+    expect(firstCategory).toHaveProperty("name");
+    expect(firstCategory).toHaveProperty("channelCount");
+    expect(firstCategory).toHaveProperty("topChannels");
+    expect(Array.isArray(firstCategory.topChannels)).toBe(true);
+  });
+});
+
+describe("getChannelsByCategory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return channels for valid category with default sort (popular)", async () => {
+    // Arrange
+    const mockChannels = [
+      {
+        id: "ch1",
+        youtube_channel_id: "UC123",
+        title: "Tech Channel",
+        description: "A tech channel",
+        thumbnail_url: "https://example.com/thumb.jpg",
+        subscriber_count: 10000,
+        review_count: 5,
+        average_rating: 4.5,
+        recent_review_count: 3,
+      },
+    ];
+
+    const mockFrom = vi.fn();
+    mockSupabase.from = mockFrom;
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "channels_with_stats") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn(() => ({
+                range: vi.fn(() =>
+                  Promise.resolve({
+                    data: mockChannels,
+                    error: null,
+                  })
+                ),
+              })),
+            })),
+          })),
+        };
+      }
+      if (table === "channels") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() =>
+              Promise.resolve({
+                count: 25,
+                error: null,
+              })
+            ),
+          })),
+        };
+      }
+      return {};
+    });
+
+    // Act
+    const result = await getChannelsByCategory("tech");
+
+    // Assert
+    expect(result).toBeDefined();
+    expect(result.channels).toEqual(mockChannels);
+    expect(result.totalCount).toBe(25);
+    expect(result.category).toEqual({
+      slug: "tech",
+      name: "テクノロジー",
+      icon: "💻",
+    });
+  });
+
+  it("should return empty result for invalid category slug", async () => {
+    // Act
+    const result = await getChannelsByCategory("invalid-slug");
+
+    // Assert
+    expect(result.channels).toEqual([]);
+    expect(result.totalCount).toBe(0);
+    expect(result.category).toBeNull();
+  });
+
+  it("should support different sort options", async () => {
+    // Arrange
+    const mockFrom = vi.fn();
+    mockSupabase.from = mockFrom;
+
+    const mockOrderSpy = vi.fn(() => ({
+      range: vi.fn(() =>
+        Promise.resolve({
+          data: [],
+          error: null,
+        })
+      ),
+    }));
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "channels_with_stats") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: mockOrderSpy,
+            })),
+          })),
+        };
+      }
+      if (table === "channels") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() =>
+              Promise.resolve({
+                count: 0,
+                error: null,
+              })
+            ),
+          })),
+        };
+      }
+      return {};
+    });
+
+    // Act - Test 'latest' sort
+    await getChannelsByCategory("tech", "latest");
+
+    // Assert
+    expect(mockOrderSpy).toHaveBeenCalledWith("created_at", {
+      ascending: false,
+    });
+
+    // Act - Test 'subscribers' sort
+    mockOrderSpy.mockClear();
+    await getChannelsByCategory("tech", "subscribers");
+
+    // Assert
+    expect(mockOrderSpy).toHaveBeenCalledWith("subscriber_count", {
+      ascending: false,
+    });
+  });
+
+  it("should handle pagination correctly", async () => {
+    // Arrange
+    const mockFrom = vi.fn();
+    mockSupabase.from = mockFrom;
+
+    const mockRangeSpy = vi.fn(() =>
+      Promise.resolve({
+        data: [],
+        error: null,
+      })
+    );
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "channels_with_stats") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              order: vi.fn(() => ({
+                range: mockRangeSpy,
+              })),
+            })),
+          })),
+        };
+      }
+      if (table === "channels") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() =>
+              Promise.resolve({
+                count: 0,
+                error: null,
+              })
+            ),
+          })),
+        };
+      }
+      return {};
+    });
+
+    // Act - Page 1, limit 20
+    await getChannelsByCategory("tech", "popular", 1, 20);
+
+    // Assert
+    expect(mockRangeSpy).toHaveBeenCalledWith(0, 19);
+
+    // Act - Page 2, limit 20
+    mockRangeSpy.mockClear();
+    await getChannelsByCategory("tech", "popular", 2, 20);
+
+    // Assert
+    expect(mockRangeSpy).toHaveBeenCalledWith(20, 39);
+  });
+});

--- a/app/_actions/__tests__/list-channel.test.ts
+++ b/app/_actions/__tests__/list-channel.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  addChannelToListAction,
+  removeChannelFromListAction,
+} from "../list-channel";
+import type { User } from "@supabase/supabase-js";
+
+// Mock dependencies
+const mockSupabase = {
+  from: vi.fn(),
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve(mockSupabase)),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getUser: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+describe("addChannelToListAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should require authentication", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue(null);
+
+    // Act
+    const result = await addChannelToListAction("list-id", "channel-id");
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("ログインが必要です");
+    }
+  });
+
+  it("should add channel to list successfully", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    const mockFrom = vi.fn();
+    mockSupabase.from = mockFrom;
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "lists") {
+        // List ownership check
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn(() =>
+                  Promise.resolve({
+                    data: { id: "list-id" },
+                    error: null,
+                  })
+                ),
+              })),
+            })),
+          })),
+        };
+      }
+      if (table === "list_channels") {
+        // Check if channel already exists
+        const selectMock = vi.fn(() => ({
+          eq: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(() =>
+                Promise.resolve({
+                  data: null, // Not exists
+                  error: null,
+                })
+              ),
+            })),
+          })),
+        }));
+
+        // Get max order_index
+        const orderMock = vi.fn(() => ({
+          limit: vi.fn(() => ({
+            single: vi.fn(() =>
+              Promise.resolve({
+                data: { order_index: 5 },
+                error: null,
+              })
+            ),
+          })),
+        }));
+
+        return {
+          select: vi.fn((columns: string) => {
+            if (columns === "id") return selectMock();
+            if (columns === "order_index")
+              return { eq: vi.fn(() => ({ order: orderMock })) };
+            return {};
+          }),
+          insert: vi.fn(() =>
+            Promise.resolve({
+              error: null,
+            })
+          ),
+        };
+      }
+      return {};
+    });
+
+    // Act
+    const result = await addChannelToListAction("list-id", "channel-id");
+
+    // Assert
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject if user does not own the list", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    const mockFrom = vi.fn();
+    mockSupabase.from = mockFrom;
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "lists") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn(() =>
+                  Promise.resolve({
+                    data: null,
+                    error: { message: "Not found" },
+                  })
+                ),
+              })),
+            })),
+          })),
+        };
+      }
+      return {};
+    });
+
+    // Act
+    const result = await addChannelToListAction("list-id", "channel-id");
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("このリストを編集する権限がありません");
+    }
+  });
+
+  it("should reject duplicate channel addition", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    const mockFrom = vi.fn();
+    mockSupabase.from = mockFrom;
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "lists") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn(() =>
+                  Promise.resolve({
+                    data: { id: "list-id" },
+                    error: null,
+                  })
+                ),
+              })),
+            })),
+          })),
+        };
+      }
+      if (table === "list_channels") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn(() =>
+                  Promise.resolve({
+                    data: { id: "existing-id" }, // Already exists
+                    error: null,
+                  })
+                ),
+              })),
+            })),
+          })),
+        };
+      }
+      return {};
+    });
+
+    // Act
+    const result = await addChannelToListAction("list-id", "channel-id");
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("このチャンネルは既にリストに追加されています");
+    }
+  });
+});
+
+describe("removeChannelFromListAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should require authentication", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue(null);
+
+    // Act
+    const result = await removeChannelFromListAction("list-id", "channel-id");
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("ログインが必要です");
+    }
+  });
+
+  it("should remove channel from list successfully", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    const mockFrom = vi.fn();
+    mockSupabase.from = mockFrom;
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "lists") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn(() =>
+                  Promise.resolve({
+                    data: { id: "list-id" },
+                    error: null,
+                  })
+                ),
+              })),
+            })),
+          })),
+        };
+      }
+      if (table === "list_channels") {
+        return {
+          delete: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() =>
+                Promise.resolve({
+                  error: null,
+                })
+              ),
+            })),
+          })),
+        };
+      }
+      return {};
+    });
+
+    // Act
+    const result = await removeChannelFromListAction("list-id", "channel-id");
+
+    // Assert
+    expect(result.success).toBe(true);
+  });
+});

--- a/app/_actions/__tests__/list.test.ts
+++ b/app/_actions/__tests__/list.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  createMyListAction,
+  updateMyListAction,
+  deleteMyListAction,
+} from "../list";
+import type { User } from "@supabase/supabase-js";
+
+// Mock dependencies
+const mockSupabase = {
+  from: vi.fn(),
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve(mockSupabase)),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getUser: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+describe("createMyListAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should require authentication", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue(null);
+
+    // Act
+    const result = await createMyListAction({
+      title: "Test List",
+      description: "Test description",
+      isPublic: true,
+    });
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("ログインが必要です");
+    }
+  });
+
+  it("should create list successfully", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    const mockList = {
+      id: "list-id",
+      title: "Test List",
+      description: "Test description",
+      is_public: true,
+    };
+
+    mockSupabase.from = vi.fn(() => ({
+      insert: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn(() =>
+            Promise.resolve({
+              data: mockList,
+              error: null,
+            })
+          ),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await createMyListAction({
+      title: "Test List",
+      description: "Test description",
+      isPublic: true,
+    });
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual(mockList);
+    }
+  });
+
+  it("should reject list title longer than 50 characters", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    // Act
+    const result = await createMyListAction({
+      title: "A".repeat(51),
+      description: "Test",
+      isPublic: true,
+    });
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateMyListAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should require authentication", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue(null);
+
+    // Act
+    const result = await updateMyListAction("list-id", {
+      title: "Updated List",
+    });
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("ログインが必要です");
+    }
+  });
+
+  it("should update list successfully", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    mockSupabase.from = vi.fn(() => ({
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn(() =>
+              Promise.resolve({
+                data: {
+                  id: "list-id",
+                  title: "Updated List",
+                },
+                error: null,
+              })
+            ),
+          })),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await updateMyListAction("list-id", {
+      title: "Updated List",
+    });
+
+    // Assert
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject update if user does not own the list", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    mockSupabase.from = vi.fn(() => ({
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn(() =>
+              Promise.resolve({
+                data: null,
+                error: { code: "PGRST116", message: "Not found" },
+              })
+            ),
+          })),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await updateMyListAction("list-id", {
+      title: "Updated List",
+    });
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("このリストを編集する権限がありません");
+    }
+  });
+});
+
+describe("deleteMyListAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should require authentication", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue(null);
+
+    // Act
+    const result = await deleteMyListAction("list-id");
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("ログインが必要です");
+    }
+  });
+
+  it("should delete list successfully", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    mockSupabase.from = vi.fn(() => ({
+      delete: vi.fn(() => ({
+        eq: vi.fn(() =>
+          Promise.resolve({
+            error: null,
+          })
+        ),
+      })),
+    }));
+
+    // Act
+    const result = await deleteMyListAction("list-id");
+
+    // Assert
+    expect(result.success).toBe(true);
+  });
+});

--- a/app/_actions/__tests__/profile.test.ts
+++ b/app/_actions/__tests__/profile.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { updateProfileAction, getCurrentProfileAction } from "../profile";
+import type { User } from "@supabase/supabase-js";
+
+// Mock dependencies
+const mockSupabase = {
+  from: vi.fn(),
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve(mockSupabase)),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getUser: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+describe("updateProfileAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should require authentication", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue(null);
+
+    // Act
+    const result = await updateProfileAction({
+      displayName: "Test User",
+      bio: "Test bio",
+    });
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("ログインが必要です");
+    }
+  });
+
+  it("should update profile successfully", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    const mockUpdatedProfile = {
+      id: "user-id",
+      email: "test@example.com",
+      username: "testuser",
+      display_name: "Updated User",
+      avatar_url: null,
+      bio: "Updated bio",
+      occupation: null,
+      gender: null,
+      birth_date: null,
+      prefecture: null,
+      website_url: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+
+    mockSupabase.from = vi.fn(() => ({
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn(() =>
+              Promise.resolve({
+                data: mockUpdatedProfile,
+                error: null,
+              })
+            ),
+          })),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await updateProfileAction({
+      displayName: "Updated User",
+      bio: "Updated bio",
+    });
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual(mockUpdatedProfile);
+    }
+  });
+
+  it("should reject profile update with invalid data", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    // Act - displayName too long
+    const result = await updateProfileAction({
+      displayName: "A".repeat(51),
+    });
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject profile update with invalid URL", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    // Act
+    const result = await updateProfileAction({
+      displayName: "Test User",
+      websiteUrl: "invalid-url",
+    });
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+
+  it("should handle Supabase error (PGRST116 - permission denied)", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    mockSupabase.from = vi.fn(() => ({
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn(() =>
+              Promise.resolve({
+                data: null,
+                error: { code: "PGRST116", message: "Not found" },
+              })
+            ),
+          })),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await updateProfileAction({
+      displayName: "Test User",
+    });
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("プロフィールを編集する権限がありません");
+    }
+  });
+});
+
+describe("getCurrentProfileAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should require authentication", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue(null);
+
+    // Act
+    const result = await getCurrentProfileAction();
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("ログインが必要です");
+    }
+  });
+
+  it("should get current profile successfully", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    const mockProfile = {
+      id: "user-id",
+      email: "test@example.com",
+      username: "testuser",
+      display_name: "Test User",
+      avatar_url: "https://example.com/avatar.jpg",
+      bio: "Test bio",
+      occupation: "Developer",
+      gender: "prefer_not_to_say",
+      birth_date: "1990-01-01",
+      prefecture: "東京都",
+      website_url: "https://example.com",
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+
+    mockSupabase.from = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn(() =>
+            Promise.resolve({
+              data: mockProfile,
+              error: null,
+            })
+          ),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await getCurrentProfileAction();
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual(mockProfile);
+    }
+  });
+
+  it("should handle Supabase error when getting profile", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    mockSupabase.from = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn(() =>
+            Promise.resolve({
+              data: null,
+              error: { message: "Database error" },
+            })
+          ),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await getCurrentProfileAction();
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("プロフィールの取得に失敗しました");
+    }
+  });
+});

--- a/app/_actions/__tests__/user-channel.test.ts
+++ b/app/_actions/__tests__/user-channel.test.ts
@@ -1,0 +1,863 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  addToMyListAction,
+  updateMyListStatusAction,
+  removeFromMyListAction,
+  getMyChannelStatusAction,
+  getMyListAction,
+} from "../user-channel";
+import type { User } from "@supabase/supabase-js";
+
+// Mock dependencies
+const mockSupabase = {
+  from: vi.fn(),
+};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => Promise.resolve(mockSupabase)),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getUser: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/types/guards", () => ({
+  extractYoutubeChannelId: vi.fn((channel) => {
+    if (channel?.youtube_channel_id) return channel.youtube_channel_id;
+    return "UCxxxxx";
+  }),
+}));
+
+describe("addToMyListAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should require authentication", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue(null);
+
+    // Act
+    const result = await addToMyListAction({
+      channelId: "UCxxxxx",
+      status: "watching",
+    });
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("ログインが必要です");
+    }
+  });
+
+  it("should add channel to my list successfully (YouTube ID)", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    let callCount = 0;
+    mockSupabase.from = vi.fn((table: string) => {
+      if (table === "channels") {
+        // Channel lookup by youtube_channel_id
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(() =>
+                Promise.resolve({
+                  data: { id: "channel-db-id" },
+                  error: null,
+                })
+              ),
+            })),
+          })),
+        };
+      }
+      if (table === "user_channels") {
+        callCount++;
+        if (callCount === 1) {
+          // First call: check existing entry
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  single: vi.fn(() =>
+                    Promise.resolve({
+                      data: null, // Not exists
+                      error: null,
+                    })
+                  ),
+                })),
+              })),
+            })),
+          };
+        } else {
+          // Second call: insert new entry
+          return {
+            insert: vi.fn(() => ({
+              select: vi.fn(() => ({
+                single: vi.fn(() =>
+                  Promise.resolve({
+                    data: {
+                      id: "user-channel-id",
+                      user_id: "user-id",
+                      channel_id: "channel-db-id",
+                      status: "watching",
+                    },
+                    error: null,
+                  })
+                ),
+              })),
+            })),
+          };
+        }
+      }
+      return {};
+    });
+
+    // Act
+    const result = await addToMyListAction({
+      channelId: "UCxxxxx",
+      status: "watching",
+    });
+
+    // Assert
+    expect(result.success).toBe(true);
+  });
+
+  it("should add channel to my list successfully (UUID)", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    const channelUUID = "123e4567-e89b-12d3-a456-426614174000";
+    let callCount = 0;
+
+    mockSupabase.from = vi.fn((table: string) => {
+      if (table === "channels") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(() =>
+                Promise.resolve({
+                  data: { id: channelUUID },
+                  error: null,
+                })
+              ),
+            })),
+          })),
+        };
+      }
+      if (table === "user_channels") {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  single: vi.fn(() =>
+                    Promise.resolve({
+                      data: null,
+                      error: null,
+                    })
+                  ),
+                })),
+              })),
+            })),
+          };
+        } else {
+          return {
+            insert: vi.fn(() => ({
+              select: vi.fn(() => ({
+                single: vi.fn(() =>
+                  Promise.resolve({
+                    data: {
+                      id: "user-channel-id",
+                      user_id: "user-id",
+                      channel_id: channelUUID,
+                      status: "watching",
+                    },
+                    error: null,
+                  })
+                ),
+              })),
+            })),
+          };
+        }
+      }
+      return {};
+    });
+
+    // Act
+    const result = await addToMyListAction({
+      channelId: channelUUID,
+      status: "watching",
+    });
+
+    // Assert
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject if channel not found", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    mockSupabase.from = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn(() =>
+            Promise.resolve({
+              data: null,
+              error: { message: "Not found" },
+            })
+          ),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await addToMyListAction({
+      channelId: "UCxxxxx",
+      status: "watching",
+    });
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("チャンネルが見つかりません");
+    }
+  });
+
+  it("should reject duplicate channel addition", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    let callCount = 0;
+    mockSupabase.from = vi.fn((table: string) => {
+      if (table === "channels") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(() =>
+                Promise.resolve({
+                  data: { id: "channel-db-id" },
+                  error: null,
+                })
+              ),
+            })),
+          })),
+        };
+      }
+      if (table === "user_channels") {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  single: vi.fn(() =>
+                    Promise.resolve({
+                      data: { id: "existing-id" }, // Already exists
+                      error: null,
+                    })
+                  ),
+                })),
+              })),
+            })),
+          };
+        }
+      }
+      return {};
+    });
+
+    // Act
+    const result = await addToMyListAction({
+      channelId: "UCxxxxx",
+      status: "watching",
+    });
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe(
+        "このチャンネルは既にマイリストに追加されています"
+      );
+    }
+  });
+});
+
+describe("updateMyListStatusAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should require authentication", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue(null);
+
+    // Act
+    const result = await updateMyListStatusAction("user-channel-id", {
+      status: "watched",
+    });
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("ログインが必要です");
+    }
+  });
+
+  it("should update status successfully", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    mockSupabase.from = vi.fn(() => ({
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn(() =>
+              Promise.resolve({
+                data: {
+                  id: "user-channel-id",
+                  status: "watched",
+                  channel: { youtube_channel_id: "UCxxxxx" },
+                },
+                error: null,
+              })
+            ),
+          })),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await updateMyListStatusAction("user-channel-id", {
+      status: "watched",
+    });
+
+    // Assert
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject if user does not own the record", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    mockSupabase.from = vi.fn(() => ({
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn(() =>
+              Promise.resolve({
+                data: null,
+                error: { code: "PGRST116", message: "Not found" },
+              })
+            ),
+          })),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await updateMyListStatusAction("user-channel-id", {
+      status: "watched",
+    });
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("このデータを編集する権限がありません");
+    }
+  });
+});
+
+describe("removeFromMyListAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should require authentication", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue(null);
+
+    // Act
+    const result = await removeFromMyListAction("user-channel-id");
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("ログインが必要です");
+    }
+  });
+
+  it("should remove channel from my list successfully", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    let callCount = 0;
+    mockSupabase.from = vi.fn((table: string) => {
+      if (table === "user_channels") {
+        callCount++;
+        if (callCount === 1) {
+          // First call: fetch for youtube_channel_id
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  single: vi.fn(() =>
+                    Promise.resolve({
+                      data: {
+                        channel: { youtube_channel_id: "UCxxxxx" },
+                      },
+                      error: null,
+                    })
+                  ),
+                })),
+              })),
+            })),
+          };
+        } else {
+          // Second call: delete
+          return {
+            delete: vi.fn(() => ({
+              eq: vi.fn(() =>
+                Promise.resolve({
+                  error: null,
+                })
+              ),
+            })),
+          };
+        }
+      }
+      return {};
+    });
+
+    // Act
+    const result = await removeFromMyListAction("user-channel-id");
+
+    // Assert
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject if user does not own the record", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    mockSupabase.from = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            single: vi.fn(() =>
+              Promise.resolve({
+                data: null,
+                error: { message: "Not found" },
+              })
+            ),
+          })),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await removeFromMyListAction("user-channel-id");
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("このデータを削除する権限がありません");
+    }
+  });
+});
+
+describe("getMyChannelStatusAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return null if not authenticated", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue(null);
+
+    // Act
+    const result = await getMyChannelStatusAction("UCxxxxx");
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBeNull();
+    }
+  });
+
+  it("should return user channel status (YouTube ID)", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    let callCount = 0;
+    mockSupabase.from = vi.fn((table: string) => {
+      if (table === "channels") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(() =>
+                Promise.resolve({
+                  data: { id: "channel-db-id" },
+                  error: null,
+                })
+              ),
+            })),
+          })),
+        };
+      }
+      if (table === "user_channels") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn(() =>
+                  Promise.resolve({
+                    data: {
+                      id: "user-channel-id",
+                      status: "watching",
+                    },
+                    error: null,
+                  })
+                ),
+              })),
+            })),
+          })),
+        };
+      }
+      return {};
+    });
+
+    // Act
+    const result = await getMyChannelStatusAction("UCxxxxx");
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({
+        id: "user-channel-id",
+        status: "watching",
+      });
+    }
+  });
+
+  it("should return null if channel not found", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    mockSupabase.from = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn(() =>
+            Promise.resolve({
+              data: null,
+              error: { message: "Not found" },
+            })
+          ),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await getMyChannelStatusAction("UCxxxxx");
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBeNull();
+    }
+  });
+
+  it("should return null if user has not added the channel", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    let callCount = 0;
+    mockSupabase.from = vi.fn((table: string) => {
+      if (table === "channels") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(() =>
+                Promise.resolve({
+                  data: { id: "channel-db-id" },
+                  error: null,
+                })
+              ),
+            })),
+          })),
+        };
+      }
+      if (table === "user_channels") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn(() =>
+                  Promise.resolve({
+                    data: null,
+                    error: { code: "PGRST116" },
+                  })
+                ),
+              })),
+            })),
+          })),
+        };
+      }
+      return {};
+    });
+
+    // Act
+    const result = await getMyChannelStatusAction("UCxxxxx");
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBeNull();
+    }
+  });
+});
+
+describe("getMyListAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should require authentication", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue(null);
+
+    // Act
+    const result = await getMyListAction();
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("ログインが必要です");
+    }
+  });
+
+  it("should get all channels in my list", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    const mockData = [
+      {
+        id: "uc1",
+        user_id: "user-id",
+        channel_id: "ch1",
+        status: "watching",
+        channel: {
+          id: "ch1",
+          youtube_channel_id: "UCxxxxx",
+          title: "Channel 1",
+        },
+      },
+      {
+        id: "uc2",
+        user_id: "user-id",
+        channel_id: "ch2",
+        status: "watched",
+        channel: {
+          id: "ch2",
+          youtube_channel_id: "UCyyyyy",
+          title: "Channel 2",
+        },
+      },
+    ];
+
+    mockSupabase.from = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          order: vi.fn(() =>
+            Promise.resolve({
+              data: mockData,
+              error: null,
+            })
+          ),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await getMyListAction();
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(2);
+    }
+  });
+
+  it("should filter by status", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = {
+      id: "user-id",
+      email: "test@example.com",
+      app_metadata: {},
+      user_metadata: {},
+      aud: "authenticated",
+      created_at: new Date().toISOString(),
+    } as User;
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    const mockData = [
+      {
+        id: "uc1",
+        user_id: "user-id",
+        channel_id: "ch1",
+        status: "watching",
+        channel: {
+          id: "ch1",
+          youtube_channel_id: "UCxxxxx",
+          title: "Channel 1",
+        },
+      },
+    ];
+
+    // Create a fully chainable query mock
+    const createQueryChain = () => {
+      const chain: any = {
+        then: (resolve: any) => resolve({ data: mockData, error: null }),
+      };
+      chain.eq = vi.fn(() => chain);
+      chain.order = vi.fn(() => chain);
+      return chain;
+    };
+
+    mockSupabase.from = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          order: vi.fn(() => createQueryChain()),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await getMyListAction("watching");
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]?.status).toBe("watching");
+    }
+  });
+});

--- a/lib/validations/user-channel.ts
+++ b/lib/validations/user-channel.ts
@@ -1,13 +1,9 @@
-import { z } from 'zod';
+import { z } from "zod";
 
 /**
  * チャンネルステータス型
  */
-export const channelStatusEnum = z.enum([
-  'want',
-  'watching',
-  'watched',
-]);
+export const channelStatusEnum = z.enum(["want", "watching", "watched"]);
 
 export type ChannelStatus = z.infer<typeof channelStatusEnum>;
 
@@ -16,8 +12,8 @@ export type ChannelStatus = z.infer<typeof channelStatusEnum>;
  */
 export const addToMyListSchema = z.object({
   channelId: z
-    .string({ message: 'チャンネルIDは必須です' })
-    .uuid('有効なチャンネルIDを指定してください'),
+    .string({ message: "チャンネルIDは必須です" })
+    .min(1, "チャンネルIDを指定してください"),
   status: channelStatusEnum,
 });
 
@@ -36,6 +32,4 @@ export const updateMyListStatusSchema = z.object({
 /**
  * ステータス更新入力型
  */
-export type UpdateMyListStatusInput = z.infer<
-  typeof updateMyListStatusSchema
->;
+export type UpdateMyListStatusInput = z.infer<typeof updateMyListStatusSchema>;


### PR DESCRIPTION
## Summary
- category.ts のテスト追加 (getCategories, getChannelsByCategory)
- list.ts のテスト追加 (createMyListAction, updateMyListAction, deleteMyListAction) 
- list-channel.ts のテスト追加 (addChannelToListAction, removeChannelFromListAction)
- profile.ts のテスト追加 (updateProfileAction, getCurrentProfileAction)
- user-channel.ts のテスト追加 (全5アクション)

## Test Coverage
各サーバーアクションについて以下をカバー:
- 認証チェック
- 正常系の動作
- バリデーションエラー
- 認可 (RLS) チェック  
- エラーハンドリング

## Bug Fix
`lib/validations/user-channel.ts` の `addToMyListSchema` を修正:
- UUID のみではなく、YouTube チャンネル ID も受け入れるように変更
- 実装との不一致を解消

## Test Plan
- [x] すべてのユニットテストが成功 (96 passed)
- [x] ESLint チェック成功
- [x] Prettier フォーマット成功

## Related Issue
Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)