### PR TITLE
fix: E2E Tests PRコメント機能とCI環境の改善

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -18,6 +18,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read # コードの読み取り
+      pull-requests: write # PRコメント投稿に必須
 
     steps:
       - name: Checkout code
@@ -26,8 +29,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
@@ -71,8 +74,19 @@ jobs:
           path: test-results/
           retention-days: 30
 
+      - name: Check if test results exist
+        id: check_results
+        if: github.event_name == 'pull_request' && always()
+        run: |
+          if [ -f "playwright-report/results.json" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "⚠️ Test results file not found - tests may not have run"
+          fi
+
       - name: Comment PR with test results
         uses: daun/playwright-report-comment@v3
-        if: github.event_name == 'pull_request' && always()
+        if: github.event_name == 'pull_request' && steps.check_results.outputs.exists == 'true'
         with:
           report-file: playwright-report/results.json

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,45 +1,45 @@
-import { defineConfig, devices } from '@playwright/test';
-import * as dotenv from 'dotenv';
-import * as path from 'path';
+import { defineConfig, devices } from "@playwright/test";
+import * as dotenv from "dotenv";
+import * as path from "path";
 
 // .env.localから環境変数を読み込む
-dotenv.config({ path: path.resolve(process.cwd(), '.env.local') });
+dotenv.config({ path: path.resolve(process.cwd(), ".env.local") });
 
 export default defineConfig({
-  testDir: './tests/e2e',
+  testDir: "./tests/e2e",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
   reporter: [
-    ['html'],
-    ['json', { outputFile: 'playwright-report/results.json' }],
+    ["html"],
+    ["json", { outputFile: "playwright-report/results.json" }],
   ],
-  globalSetup: './tests/fixtures/test-data-setup.ts',
+  globalSetup: "./tests/fixtures/test-data-setup.ts",
   use: {
-    baseURL: 'http://localhost:3000',
-    trace: 'on-first-retry',
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
     // デフォルトのナビゲーション待機戦略
     navigationTimeout: 30000,
     actionTimeout: 10000,
   },
   projects: [
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
     },
     {
-      name: 'mobile-chrome',
-      use: { ...devices['Pixel 5'] },
+      name: "mobile-chrome",
+      use: { ...devices["Pixel 5"] },
     },
     {
-      name: 'tablet',
-      use: { ...devices['iPad Pro'] },
+      name: "tablet",
+      use: { ...devices["iPad Pro"] },
     },
   ],
   webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:3000',
+    command: process.env.CI ? "npm run start" : "npm run dev",
+    url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120000,
   },


### PR DESCRIPTION
## 🔗 関連Issue
関連Issue番号なし（ワークフローログから直接発見した問題の修正）

---

## 📋 概要
E2E Tests ワークフローにおけるPRコメント投稿機能の修復と、CI環境での本番ビルド使用による品質向上を実施しました。

## 🎯 背景・目的

### 発見された問題
1. **PRコメント投稿が完全に失敗**（最重大）
   - エラー: "Resource not accessible by integration"
   - 原因: `GITHUB_TOKEN` に `pull-requests: write` 権限が不足
   - 影響: PRコメント機能が動作していない（全てのPRで失敗）

2. **ビルド失敗時の不要なエラー表示**（中）
   - エラー: "Report file playwright-report/results.json not found"
   - 原因: テスト未実行でも `always()` により results.json を要求
   - 影響: dependabot PRで常にノイズが発生

3. **CI環境で開発サーバーを使用**（低）
   - 問題: `npm run dev` を使用（本番環境との挙動差）
   - 影響: 本番環境特有の問題を検出できない可能性

### 目的
- PRコメント機能を正常化し、テスト結果の可視性を向上
- CI環境での誤検知やノイズを削減
- 本番環境を正確に再現したテスト実行環境を構築

## 📝 変更内容

### 主な変更

#### 1. GITHUB_TOKEN権限の追加（`.github/workflows/e2e-tests.yml`）
```yaml
permissions:
  contents: read         # コードの読み取り
  pull-requests: write   # PRコメント投稿に必須
```
- `daun/playwright-report-comment@v3` がPRコメントを投稿可能に
- dependabot PRでも動作（GitHub標準の権限委譲）

#### 2. results.json存在チェックの追加（`.github/workflows/e2e-tests.yml`）
```yaml
- name: Check if test results exist
  id: check_results
  if: github.event_name == 'pull_request' && always()
  run: |
    if [ -f "playwright-report/results.json" ]; then
      echo "exists=true" >> $GITHUB_OUTPUT
    else
      echo "exists=false" >> $GITHUB_OUTPUT
      echo "⚠️ Test results file not found - tests may not have run"
    fi

- name: Comment PR with test results
  uses: daun/playwright-report-comment@v3
  if: github.event_name == 'pull_request' && steps.check_results.outputs.exists == 'true'
  with:
    report-file: playwright-report/results.json
```
- ファイル存在を確認してからコメント投稿
- ビルド失敗時（テスト未実行）でもエラーなし

#### 3. CI環境での本番ビルド使用（`playwright.config.ts`）
```typescript
webServer: {
  command: process.env.CI ? 'npm run start' : 'npm run dev',
  url: 'http://localhost:3000',
  reuseExistingServer: !process.env.CI,
  timeout: 120000,
},
```
- CI: `npm run start`（本番ビルド）
- ローカル: `npm run dev`（開発サーバー）
- ワークフローで既に `npm run build` 実行済み（追加ビルド不要）

### 技術的な詳細

**権限設計**
- 最小権限の原則: 必要な権限のみ付与（`contents: read`, `pull-requests: write`）
- Forkからの PR: セキュリティ制限により write 権限は付与されない（意図的な動作）

**エラーハンドリング**
- ファイル存在チェックを条件分岐に組み込み
- `GITHUB_OUTPUT` を使用してステップ間で状態を共有
- デバッグしやすいログメッセージを出力

**環境分離**
- `process.env.CI` による環境判定
- ワークフローの `.env.local` 設定を両ステップで共有（38-48行目）
- Next.js 公式ベストプラクティスに準拠

### ファイル変更サマリー
- `.github/workflows/e2e-tests.yml` - GITHUB_TOKEN権限追加、results.json存在チェック追加
- `playwright.config.ts` - CI環境で本番ビルド使用

## 🧪 テスト

### テスト方法
```bash
# 1. ブランチをチェックアウト
git checkout fix/e2e-test-pr-comments

# 2. ローカルでE2Eテスト実行（開発サーバーを使用することを確認）
npm run test:e2e

# 3. CI環境をシミュレート（本番ビルドを使用することを確認）
npm run build
CI=true npx playwright test
```

### テストケース
- [x] ローカル開発: `npm run dev` が使用される
- [x] CI環境: `npm run start` が使用される
- [ ] PRコメント投稿: 実際のPRで確認必要（このPRでテスト）
- [x] results.json存在チェック: ファイルがない場合にスキップされる

### 動作確認済み環境
- [x] ローカル開発環境 (Node.js 20.x)
- [x] ビルド成功 (`npm run build`)
- [x] Lint/Type Check通過
- [ ] 実際のCI環境での動作確認（このPRで検証）

## 📷 スクリーンショット / 動画

### Before
- ワークフローログ（run ID: 22048201330）:
  ```
  Error: HttpError: Resource not accessible by integration
  ```
- dependabot PR:
  ```
  Error: Report file playwright-report/results.json not found
  ```

### After
- PRコメントが正常に投稿される（このPRで確認予定）
- ビルド失敗時もエラーなし（チェックステップでスキップ）

## 🚨 影響範囲

### 破壊的変更
- [x] なし（既存機能の改善のみ）

### パフォーマンスへの影響
- [x] 改善あり
  - 詳細: CI環境での起動オーバーヘッド削減（`npm run dev` の不要なコンパイルなし）

### セキュリティへの影響
- [x] 影響なし
  - 最小権限の原則に従った権限付与
  - Fork からの PR は既存のセキュリティモデルを維持

## ✅ セルフチェックリスト

### コード品質
- [x] コードレビュー観点を自己確認済み
- [x] 変数名・関数名が適切で理解しやすい
- [x] 不要なコメントアウトやconsole.logを削除
- [x] DRY原則に従い、重複コードを排除

### TypeScript
- [x] 型安全性を確保（`any`型を使用していない）
- [x] 型エラーがない
- [x] 必要に応じて型定義を追加（該当なし）

### テスト
- [x] ユニットテストを追加/更新（該当なし：ワークフロー設定変更）
- [x] E2Eテストを追加/更新（該当なし：E2Eテスト自体は変更なし）
- [x] 既存テストが全て通過（ローカルで確認済み）

### ドキュメント
- [x] README更新（不要：内部ワークフローの改善）
- [x] コードコメント追加（YAML内にコメント追加済み）
- [x] API仕様書更新（該当なし）
- [x] マイグレーションガイド作成（該当なし：破壊的変更なし）

### セキュリティ
- [x] 環境変数を適切に管理（既存の設定を維持）
- [x] 機密情報をハードコードしていない
- [x] 入力値のバリデーション実装（該当なし）
- [x] XSS/CSRF対策を考慮（該当なし：GitHub Actions設定）

### 品質保証
- [x] ESLint通過
- [x] Prettier適用（pre-commit hookで自動適用）
- [x] ビルド成功
- [x] 開発サーバー起動確認

## 👀 レビューポイント

### 設計上の確認ポイント

#### 1. 権限設計の妥当性
- `pull-requests: write` の付与は適切か？
  - ✅ **判断**: 適切。PRコメント機能に必須であり、最小権限の原則に従っている
  - セキュリティ: dependabot PRでも安全（GitHub標準の権限委譲）

#### 2. エラーハンドリング戦略
- `always()` から条件分岐への変更は適切か？
  - ✅ **判断**: 適切。ファイル存在を明示的にチェックすることでエラーの原因が明確に
  - デバッグしやすさ: ログメッセージでスキップ理由を出力

#### 3. CI環境と本番環境の一貫性
- CI で `npm run start` を使用する設計は妥当か？
  - ✅ **判断**: 妥当。Next.js公式推奨（本番環境を正確に再現）
  - トレードオフ: ビルド時間は増えないが、起動時間は若干短縮
  - ローカル開発への影響: なし（`process.env.CI` で分岐）

#### 4. ワークフロー全体の整合性
- 既存のステップとの依存関係に矛盾はないか？
  - ✅ **確認済み**: ワークフロー51行目で `npm run build` を実行
  - ✅ **確認済み**: 環境変数は38-48行目で設定済み
  - ✅ **確認済み**: テスト実行（54行目）→ ファイルチェック（77行目）→ コメント投稿（88行目）の順序が適切

### 特に確認してほしい箇所
1. **権限設計**: `pull-requests: write` の付与がセキュリティポリシーに適合しているか
2. **条件分岐ロジック**: `steps.check_results.outputs.exists == 'true'` の判定が全てのケースで正しく動作するか
3. **環境分離**: `process.env.CI` による分岐がローカル開発を阻害しないか

## 📚 参考資料
- [GitHub Actions: Permissions for GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
- [Next.js Testing: Best Practices](https://nextjs.org/docs/testing)
- [Playwright CI Configuration](https://playwright.dev/docs/ci)
- ワークフローエラーログ: Actions run ID 22048201330

## 💬 補足事項

### 優先度と段階的修正
この修正は3つの問題を段階的に解決していますが、全て独立しており破壊的変更はありません：
1. **Phase 1（最優先）**: GITHUB_TOKEN権限追加 → PRコメント機能復旧
2. **Phase 2（中）**: results.json存在チェック → ノイズ削減
3. **Phase 3（低）**: 本番ビルド使用 → 品質向上

### 検証方法
このPR自体がテストケースになります：
- PRコメントが正常に投稿されるか確認
- CI環境で `npm run start` が使用されるか確認
- エラーログに "Resource not accessible" が出ないか確認

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)