### PR TITLE
fix: Remove ZodError.details leakage from API error responses

### DIFF
--- a/app/_actions/youtube.ts
+++ b/app/_actions/youtube.ts
@@ -37,7 +37,6 @@ export async function searchChannelsAction(
       return {
         success: false,
         error: err.issues[0]?.message || "Validation error",
-        details: err.issues,
       };
     }
 
@@ -46,7 +45,6 @@ export async function searchChannelsAction(
       return {
         success: false,
         error: getErrorMessage(err.code),
-        details: err.details,
       };
     }
 
@@ -113,7 +111,6 @@ export async function getChannelDetailsAction(
       return {
         success: false,
         error: err.issues[0]?.message || "Validation error",
-        details: err.issues,
       };
     }
 
@@ -122,7 +119,6 @@ export async function getChannelDetailsAction(
       return {
         success: false,
         error: getErrorMessage(err.code),
-        details: err.details,
       };
     }
 

--- a/lib/api/__tests__/error.test.ts
+++ b/lib/api/__tests__/error.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { z } from "zod";
+import { ApiError, handleApiError } from "../error";
+
+describe("handleApiError", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should handle ApiError and return error message", () => {
+    // Arrange
+    const error = new ApiError("UNAUTHORIZED", "ログインが必要です", 401);
+
+    // Act
+    const result = handleApiError(error);
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("ログインが必要です");
+      expect(result).not.toHaveProperty("details");
+    }
+  });
+
+  it("should handle ZodError without exposing details", () => {
+    // Arrange
+    const schema = z.object({
+      name: z.string().min(1, "名前は必須です"),
+      age: z.number().min(0, "年齢は0以上です"),
+    });
+
+    let zodError: z.ZodError | undefined;
+    try {
+      schema.parse({ name: "", age: -1 });
+    } catch (e) {
+      if (e instanceof z.ZodError) {
+        zodError = e;
+      }
+    }
+
+    expect(zodError).toBeDefined();
+
+    // Act
+    const result = handleApiError(zodError!);
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      // ZodError の最初の issue メッセージのみが返される
+      expect(result.error).toBe("名前は必須です");
+      // details が含まれていないこと（セキュリティ要件）
+      expect(result).not.toHaveProperty("details");
+    }
+  });
+
+  it("should not expose ZodError issues array to client", () => {
+    // Arrange
+    const schema = z.object({
+      email: z.string().email("メールアドレスが不正です"),
+    });
+
+    let zodError: z.ZodError | undefined;
+    try {
+      schema.parse({ email: "invalid" });
+    } catch (e) {
+      if (e instanceof z.ZodError) {
+        zodError = e;
+      }
+    }
+
+    // Act
+    const result = handleApiError(zodError!);
+
+    // Assert
+    if (!result.success) {
+      // issues 配列が直接レスポンスに含まれていないこと
+      expect(JSON.stringify(result)).not.toContain("issues");
+      expect(result).not.toHaveProperty("details");
+    }
+  });
+
+  it("should return first issue message for ZodError with multiple issues", () => {
+    // Arrange
+    const schema = z.object({
+      name: z.string().min(1, "first error"),
+      email: z.string().email("second error"),
+    });
+
+    let zodError: z.ZodError | undefined;
+    try {
+      schema.parse({ name: "", email: "bad" });
+    } catch (e) {
+      if (e instanceof z.ZodError) {
+        zodError = e;
+      }
+    }
+
+    // Act
+    const result = handleApiError(zodError!);
+
+    // Assert
+    if (!result.success) {
+      expect(result.error).toBe("first error");
+    }
+  });
+
+  it("should handle unexpected errors and return generic message", () => {
+    // Arrange
+    const error = new Error("Something went wrong");
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Act
+    const result = handleApiError(error);
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("Internal server error");
+      expect(result).not.toHaveProperty("details");
+    }
+    expect(consoleSpy).toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+
+  it("should handle non-Error objects gracefully", () => {
+    // Arrange
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Act
+    const result = handleApiError("string error");
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("Internal server error");
+    }
+
+    consoleSpy.mockRestore();
+  });
+});
+
+describe("ApiError", () => {
+  it("should create an ApiError with correct properties", () => {
+    // Act
+    const error = new ApiError("NOT_FOUND", "リソースが見つかりません", 404);
+
+    // Assert
+    expect(error.code).toBe("NOT_FOUND");
+    expect(error.message).toBe("リソースが見つかりません");
+    expect(error.statusCode).toBe(404);
+    expect(error.name).toBe("ApiError");
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("should default to 500 status code", () => {
+    // Act
+    const error = new ApiError("INTERNAL_ERROR", "サーバーエラー");
+
+    // Assert
+    expect(error.statusCode).toBe(500);
+  });
+});

--- a/lib/api/error.ts
+++ b/lib/api/error.ts
@@ -1,5 +1,5 @@
-import { z } from 'zod';
-import type { ApiResponse, ApiErrorCode } from '@/lib/types/api';
+import { z } from "zod";
+import type { ApiResponse, ApiErrorCode } from "@/lib/types/api";
 
 /**
  * APIエラークラス
@@ -11,7 +11,7 @@ export class ApiError extends Error {
     public statusCode: number = 500
   ) {
     super(message);
-    this.name = 'ApiError';
+    this.name = "ApiError";
   }
 }
 
@@ -29,14 +29,13 @@ export function handleApiError(error: unknown): ApiResponse<never> {
   if (error instanceof z.ZodError) {
     return {
       success: false,
-      error: 'Validation error',
-      details: error.issues,
+      error: error.issues[0]?.message || "Validation error",
     };
   }
 
-  console.error('Unexpected error:', error);
+  console.error("Unexpected error:", error);
   return {
     success: false,
-    error: 'Internal server error',
+    error: "Internal server error",
   };
 }


### PR DESCRIPTION
## Summary

- `handleApiError()` の ZodError 処理で `error.issues` をそのままクライアントに返していたセキュリティルール違反を修正
- `youtube.ts` アクション内の ZodError/YouTubeApiError ハンドリングからも `details` フィールドを削除
- `handleApiError()` の包括的なユニットテストを新規追加

## Changes

### `lib/api/error.ts`
- ZodError 発生時に `details: error.issues` を返さないように修正
- 汎用的な `'Validation error'` ではなく、最初の issue メッセージを返すように改善

### `app/_actions/youtube.ts`
- `searchChannelsAction`: ZodError/YouTubeApiError の `details` フィールド削除
- `getChannelDetailsAction`: ZodError/YouTubeApiError の `details` フィールド削除

### `lib/api/__tests__/error.test.ts` (新規)
- `handleApiError()` の8テストケース追加
  - ApiError、ZodError、予期しないエラー、非Errorオブジェクトの各ハンドリング
  - ZodError の `details` / `issues` が漏洩しないことの検証
  - 複数 issues 時に最初のメッセージのみ返されることの検証

## Test plan

- [x] 新規テスト `lib/api/__tests__/error.test.ts` (8テスト) 全パス
- [x] 既存ユニットテスト全170テスト パス
- [x] TypeScript 型チェック (`tsc --noEmit`) パス
- [x] pre-commit hooks (ESLint + Prettier) パス

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)