### PR TITLE
fix: Add CI job dependencies and standardize env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
 
   typecheck:
     name: Type Check
+    needs: lint
     runs-on: ubuntu-latest
 
     steps:
@@ -49,6 +50,7 @@ jobs:
 
   test:
     name: Unit Tests
+    needs: typecheck
     runs-on: ubuntu-latest
 
     steps:
@@ -71,7 +73,7 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key
           YOUTUBE_API_KEY=dummy-youtube-api-key
           SUPABASE_SERVICE_ROLE_KEY=dummy-service-role-key
-          NEXTAUTH_SECRET=${{ secrets.NEXTAUTH_SECRET }}
+          NEXTAUTH_SECRET=dummy-nextauth-secret-for-ci-testing
           NEXTAUTH_URL=http://localhost:3000
           EOF
 
@@ -80,6 +82,7 @@ jobs:
 
   build:
     name: Build
+    needs: typecheck
     runs-on: ubuntu-latest
 
     steps:
@@ -102,7 +105,7 @@ jobs:
           NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy-anon-key
           YOUTUBE_API_KEY=dummy-youtube-api-key
           SUPABASE_SERVICE_ROLE_KEY=dummy-service-role-key
-          NEXTAUTH_SECRET=${{ secrets.NEXTAUTH_SECRET }}
+          NEXTAUTH_SECRET=dummy-nextauth-secret-for-ci-build
           NEXTAUTH_URL=http://localhost:3000
           EOF
 


### PR DESCRIPTION
## Summary

- CIジョブ間に `needs` 依存関係を追加し、lint失敗時に後続ジョブをスキップ
- `.env.local` の `NEXTAUTH_SECRET` を Secrets 参照からダミー値に統一

## Changes

### CI依存関係の追加 (#153)
```
lint → typecheck → test (並列)
                 → build (並列)
db-migration (独立)
```
- lint失敗 → typecheck/test/build がスキップされる
- typecheck失敗 → test/build がスキップされる
- db-migration は supabase 関連のみなので独立実行

### 環境変数の整理 (#155)
- test/build ジョブの `NEXTAUTH_SECRET=${{ secrets.NEXTAUTH_SECRET }}` をダミー値に変更
- ユニットテスト・ビルドには実際のシークレットは不要
- 全環境変数がダミー値で統一され、混在が解消

## Test plan

- [x] YAML 構文検証済み
- [x] pre-commit hooks (Prettier) パス
- [x] CI パイプラインの動作は PR マージ後に自動検証される

Closes #153
Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)