### PR TITLE
refactor: Extract helper functions from getChannelReviewsAction

### DIFF
--- a/app/_actions/review.ts
+++ b/app/_actions/review.ts
@@ -7,7 +7,11 @@ import { ApiError, handleApiError } from "@/lib/api/error";
 import { API_ERROR_CODES, type ApiResponse } from "@/lib/types/api";
 import { DB_ERROR_CODES } from "@/lib/constants/database-errors";
 import { extractYoutubeChannelId } from "@/lib/types/guards";
-import { isUUID } from "@/lib/validation-utils";
+import { findChannelDbId } from "@/lib/supabase/channel-query";
+import {
+  fetchUserHelpfulVotes,
+  transformReviewsWithUser,
+} from "@/lib/review-helpers";
 import {
   createReviewSchema,
   updateReviewSchema,
@@ -18,7 +22,6 @@ import {
 import type {
   Review,
   PaginatedReviews,
-  ReviewWithUser,
   ReviewWithUserAndChannel,
   PaginatedMyReviews,
 } from "@/lib/types/review";
@@ -46,47 +49,16 @@ export async function createReviewAction(
     // Supabaseクライアント作成
     const supabase = await createClient();
 
-    // channelIdがUUID形式かどうかをチェック
-    const isChannelUUID = isUUID(validated.channelId);
-
-    let channelDbId: string;
-
-    if (isChannelUUID) {
-      // UUID形式の場合は直接データベースIDとして使用
-      channelDbId = validated.channelId;
-
-      // チャンネルの存在確認
-      const { data: channel, error: channelError } = await supabase
-        .from("channels")
-        .select("id")
-        .eq("id", channelDbId)
-        .single();
-
-      if (channelError || !channel) {
-        throw new ApiError(
-          API_ERROR_CODES.NOT_FOUND,
-          "チャンネルが見つかりません",
-          404
-        );
-      }
-    } else {
-      // YouTube IDの場合は検索
-      const { data: channel, error: channelError } = await supabase
-        .from("channels")
-        .select("id")
-        .eq("youtube_channel_id", validated.channelId)
-        .single();
-
-      if (channelError || !channel) {
-        throw new ApiError(
-          API_ERROR_CODES.NOT_FOUND,
-          "チャンネルが見つかりません",
-          404
-        );
-      }
-
-      channelDbId = channel.id;
+    // チャンネルのデータベースIDを解決
+    const channelLookup = await findChannelDbId(supabase, validated.channelId);
+    if (!channelLookup.found) {
+      throw new ApiError(
+        API_ERROR_CODES.NOT_FOUND,
+        "チャンネルが見つかりません",
+        404
+      );
     }
+    const channelDbId = channelLookup.channelDbId;
 
     // レビューを挿入
     const { data, error } = await supabase
@@ -155,61 +127,23 @@ export async function getChannelReviewsAction(
     // 現在のユーザーを取得（オプショナル）
     const user = await getUser();
 
-    // channelIdがUUID形式かどうかをチェック
-    const isChannelUUID = isUUID(youtubeChannelId);
-
-    let channelDbId: string;
-
-    if (isChannelUUID) {
-      // UUID形式の場合は直接データベースIDとして使用
-      channelDbId = youtubeChannelId;
-
-      // チャンネルの存在確認
-      const { data: channel, error: channelError } = await supabase
-        .from("channels")
-        .select("id")
-        .eq("id", channelDbId)
-        .single();
-
-      if (channelError || !channel) {
-        return {
-          success: true,
-          data: {
-            reviews: [],
-            pagination: {
-              page: validated.page,
-              limit: validated.limit,
-              total: 0,
-              totalPages: 0,
-            },
+    // チャンネルのデータベースIDを解決
+    const channelLookup = await findChannelDbId(supabase, youtubeChannelId);
+    if (!channelLookup.found) {
+      return {
+        success: true,
+        data: {
+          reviews: [],
+          pagination: {
+            page: validated.page,
+            limit: validated.limit,
+            total: 0,
+            totalPages: 0,
           },
-        };
-      }
-    } else {
-      // YouTube IDの場合は検索
-      const { data: channel, error: channelError } = await supabase
-        .from("channels")
-        .select("id")
-        .eq("youtube_channel_id", youtubeChannelId)
-        .single();
-
-      if (channelError || !channel) {
-        return {
-          success: true,
-          data: {
-            reviews: [],
-            pagination: {
-              page: validated.page,
-              limit: validated.limit,
-              total: 0,
-              totalPages: 0,
-            },
-          },
-        };
-      }
-
-      channelDbId = channel.id;
+        },
+      };
     }
+    const channelDbId = channelLookup.channelDbId;
 
     const offset = (validated.page - 1) * validated.limit;
 
@@ -260,32 +194,19 @@ export async function getChannelReviewsAction(
     }
 
     // ログインユーザーの投票状態を取得
-    let userHelpfulVotes: Set<string> = new Set();
-    if (user && reviews && reviews.length > 0) {
-      const reviewIds = reviews.map((r) => r.id);
-      const { data: helpfulData } = await supabase
-        .from("review_helpful")
-        .select("review_id")
-        .in("review_id", reviewIds)
-        .eq("user_id", user.id);
-
-      if (helpfulData) {
-        userHelpfulVotes = new Set(helpfulData.map((h) => h.review_id));
-      }
-    }
+    const userHelpfulVotes =
+      user && reviews && reviews.length > 0
+        ? await fetchUserHelpfulVotes(
+            supabase,
+            user.id,
+            reviews.map((r) => r.id)
+          )
+        : new Set<string>();
 
     // レビューデータを変換（user を配列から単一オブジェクトに、is_helpful を追加）
-    const transformedReviews: ReviewWithUser[] = (reviews || []).map(
-      (review) => {
-        const reviewUser = Array.isArray(review.user)
-          ? review.user[0]
-          : review.user;
-        return {
-          ...review,
-          user: reviewUser,
-          is_helpful: userHelpfulVotes.has(review.id),
-        } as ReviewWithUser;
-      }
+    const transformedReviews = transformReviewsWithUser(
+      reviews || [],
+      userHelpfulVotes
     );
 
     // ページネーション情報を構築

--- a/lib/__tests__/review-helpers.test.ts
+++ b/lib/__tests__/review-helpers.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  fetchUserHelpfulVotes,
+  transformReviewsWithUser,
+} from "../review-helpers";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+describe("fetchUserHelpfulVotes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return empty set for empty reviewIds", async () => {
+    const mockSupabase = {} as SupabaseClient;
+
+    const result = await fetchUserHelpfulVotes(mockSupabase, "user-1", []);
+
+    expect(result).toEqual(new Set());
+  });
+
+  it("should return set of voted review IDs", async () => {
+    const mockSupabase = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          in: vi.fn(() => ({
+            eq: vi.fn(() =>
+              Promise.resolve({
+                data: [{ review_id: "rev-1" }, { review_id: "rev-3" }],
+                error: null,
+              })
+            ),
+          })),
+        })),
+      })),
+    } as unknown as SupabaseClient;
+
+    const result = await fetchUserHelpfulVotes(mockSupabase, "user-1", [
+      "rev-1",
+      "rev-2",
+      "rev-3",
+    ]);
+
+    expect(result).toEqual(new Set(["rev-1", "rev-3"]));
+    expect(result.has("rev-1")).toBe(true);
+    expect(result.has("rev-2")).toBe(false);
+    expect(result.has("rev-3")).toBe(true);
+  });
+
+  it("should return empty set when helpfulData is null", async () => {
+    const mockSupabase = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          in: vi.fn(() => ({
+            eq: vi.fn(() =>
+              Promise.resolve({
+                data: null,
+                error: { message: "Error" },
+              })
+            ),
+          })),
+        })),
+      })),
+    } as unknown as SupabaseClient;
+
+    const result = await fetchUserHelpfulVotes(mockSupabase, "user-1", [
+      "rev-1",
+    ]);
+
+    expect(result).toEqual(new Set());
+  });
+
+  it("should query review_helpful table with correct parameters", async () => {
+    const mockEq = vi.fn(() =>
+      Promise.resolve({
+        data: [],
+        error: null,
+      })
+    );
+
+    const mockIn = vi.fn(() => ({
+      eq: mockEq,
+    }));
+
+    const mockSelect = vi.fn(() => ({
+      in: mockIn,
+    }));
+
+    const mockSupabase = {
+      from: vi.fn(() => ({
+        select: mockSelect,
+      })),
+    } as unknown as SupabaseClient;
+
+    await fetchUserHelpfulVotes(mockSupabase, "user-123", ["rev-1", "rev-2"]);
+
+    expect(mockSupabase.from).toHaveBeenCalledWith("review_helpful");
+    expect(mockSelect).toHaveBeenCalledWith("review_id");
+    expect(mockIn).toHaveBeenCalledWith("review_id", ["rev-1", "rev-2"]);
+    expect(mockEq).toHaveBeenCalledWith("user_id", "user-123");
+  });
+});
+
+describe("transformReviewsWithUser", () => {
+  it("should transform reviews with single user object", () => {
+    const reviews = [
+      {
+        id: "rev-1",
+        user_id: "user-1",
+        channel_id: "ch-1",
+        rating: 5,
+        title: "Great",
+        content: "Excellent",
+        is_spoiler: false,
+        helpful_count: 10,
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+        deleted_at: null,
+        user: {
+          id: "user-1",
+          username: "testuser",
+          display_name: "Test User",
+          avatar_url: "https://example.com/avatar.jpg",
+        },
+      },
+    ];
+
+    const result = transformReviewsWithUser(reviews, new Set(["rev-1"]));
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.user.username).toBe("testuser");
+    expect(result[0]?.is_helpful).toBe(true);
+  });
+
+  it("should transform reviews with array user (Supabase JOIN result)", () => {
+    const reviews = [
+      {
+        id: "rev-1",
+        user_id: "user-1",
+        channel_id: "ch-1",
+        rating: 4,
+        title: null,
+        content: "Good",
+        is_spoiler: false,
+        helpful_count: 5,
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+        deleted_at: null,
+        user: [
+          {
+            id: "user-1",
+            username: "arrayuser",
+            display_name: "Array User",
+            avatar_url: null,
+          },
+        ],
+      },
+    ];
+
+    const result = transformReviewsWithUser(reviews, new Set());
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.user.username).toBe("arrayuser");
+    expect(result[0]?.is_helpful).toBe(false);
+  });
+
+  it("should set is_helpful based on userHelpfulVotes", () => {
+    const reviews = [
+      {
+        id: "rev-1",
+        user: { id: "u1", username: "a", display_name: null, avatar_url: null },
+      },
+      {
+        id: "rev-2",
+        user: { id: "u2", username: "b", display_name: null, avatar_url: null },
+      },
+      {
+        id: "rev-3",
+        user: { id: "u3", username: "c", display_name: null, avatar_url: null },
+      },
+    ] as Array<{
+      id: string;
+      user: {
+        id: string;
+        username: string;
+        display_name: string | null;
+        avatar_url: string | null;
+      };
+    }>;
+
+    const votes = new Set(["rev-1", "rev-3"]);
+    const result = transformReviewsWithUser(reviews, votes);
+
+    expect(result[0]?.is_helpful).toBe(true);
+    expect(result[1]?.is_helpful).toBe(false);
+    expect(result[2]?.is_helpful).toBe(true);
+  });
+
+  it("should return empty array for empty reviews", () => {
+    const result = transformReviewsWithUser([], new Set());
+    expect(result).toEqual([]);
+  });
+});

--- a/lib/review-helpers.ts
+++ b/lib/review-helpers.ts
@@ -1,0 +1,74 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { ReviewWithUser } from "@/lib/types/review";
+
+/**
+ * ログインユーザーの「参考になった」投票済みレビューIDセットを取得する
+ *
+ * @param supabase Supabaseクライアント
+ * @param userId ユーザーID
+ * @param reviewIds 対象レビューIDの配列
+ * @returns 投票済みレビューIDのSet
+ */
+export async function fetchUserHelpfulVotes(
+  supabase: SupabaseClient,
+  userId: string,
+  reviewIds: string[]
+): Promise<Set<string>> {
+  if (reviewIds.length === 0) {
+    return new Set();
+  }
+
+  const { data: helpfulData } = await supabase
+    .from("review_helpful")
+    .select("review_id")
+    .in("review_id", reviewIds)
+    .eq("user_id", userId);
+
+  if (!helpfulData) {
+    return new Set();
+  }
+
+  return new Set(helpfulData.map((h) => h.review_id));
+}
+
+/**
+ * Supabaseから取得したレビューデータをReviewWithUser型に変換する
+ *
+ * Supabase JOINの結果、userが配列になる場合があるため単一オブジェクトに変換し、
+ * is_helpfulフラグを付与する。
+ *
+ * @param reviews Supabaseから取得した生のレビューデータ
+ * @param userHelpfulVotes ユーザーの投票済みレビューIDセット
+ * @returns 変換後のReviewWithUser配列
+ */
+export function transformReviewsWithUser(
+  reviews: Array<{
+    id: string;
+    user:
+      | {
+          id: string;
+          username: string;
+          display_name: string | null;
+          avatar_url: string | null;
+        }
+      | Array<{
+          id: string;
+          username: string;
+          display_name: string | null;
+          avatar_url: string | null;
+        }>;
+    [key: string]: unknown;
+  }>,
+  userHelpfulVotes: Set<string>
+): ReviewWithUser[] {
+  return reviews.map((review) => {
+    const reviewUser = Array.isArray(review.user)
+      ? review.user[0]
+      : review.user;
+    return {
+      ...review,
+      user: reviewUser,
+      is_helpful: userHelpfulVotes.has(review.id),
+    } as ReviewWithUser;
+  });
+}

--- a/lib/supabase/__tests__/channel-query.test.ts
+++ b/lib/supabase/__tests__/channel-query.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { findChannelDbId } from "../channel-query";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// Supabase mock を作成するヘルパー
+function createMockSupabase(overrides?: {
+  selectData?: { id: string } | null;
+  selectError?: { message: string } | null;
+}): SupabaseClient {
+  const { selectData = null, selectError = null } = overrides || {};
+
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          single: vi.fn(() =>
+            Promise.resolve({
+              data: selectData,
+              error: selectError,
+            })
+          ),
+        })),
+      })),
+    })),
+  } as unknown as SupabaseClient;
+}
+
+describe("findChannelDbId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should find channel by UUID", async () => {
+    const channelId = "550e8400-e29b-41d4-a716-446655440000";
+    const mockSupabase = createMockSupabase({
+      selectData: { id: channelId },
+    });
+
+    const result = await findChannelDbId(mockSupabase, channelId);
+
+    expect(result).toEqual({ found: true, channelDbId: channelId });
+    expect(mockSupabase.from).toHaveBeenCalledWith("channels");
+  });
+
+  it("should find channel by YouTube ID", async () => {
+    const youtubeChannelId = "UCXuqSBlHAE6Xw-yeJA0Tunw";
+    const dbId = "550e8400-e29b-41d4-a716-446655440000";
+    const mockSupabase = createMockSupabase({
+      selectData: { id: dbId },
+    });
+
+    const result = await findChannelDbId(mockSupabase, youtubeChannelId);
+
+    expect(result).toEqual({ found: true, channelDbId: dbId });
+    expect(mockSupabase.from).toHaveBeenCalledWith("channels");
+  });
+
+  it("should return found:false when UUID channel not found", async () => {
+    const channelId = "550e8400-e29b-41d4-a716-446655440000";
+    const mockSupabase = createMockSupabase({
+      selectData: null,
+      selectError: { message: "Not found" },
+    });
+
+    const result = await findChannelDbId(mockSupabase, channelId);
+
+    expect(result).toEqual({ found: false });
+  });
+
+  it("should return found:false when YouTube ID channel not found", async () => {
+    const youtubeChannelId = "UCNonExistent";
+    const mockSupabase = createMockSupabase({
+      selectData: null,
+      selectError: { message: "Not found" },
+    });
+
+    const result = await findChannelDbId(mockSupabase, youtubeChannelId);
+
+    expect(result).toEqual({ found: false });
+  });
+
+  it("should query by id column for UUID format", async () => {
+    const channelId = "550e8400-e29b-41d4-a716-446655440000";
+
+    const mockEq = vi.fn(() => ({
+      single: vi.fn(() =>
+        Promise.resolve({
+          data: { id: channelId },
+          error: null,
+        })
+      ),
+    }));
+
+    const mockSupabase = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: mockEq,
+        })),
+      })),
+    } as unknown as SupabaseClient;
+
+    await findChannelDbId(mockSupabase, channelId);
+
+    expect(mockEq).toHaveBeenCalledWith("id", channelId);
+  });
+
+  it("should query by youtube_channel_id column for non-UUID format", async () => {
+    const youtubeChannelId = "UCXuqSBlHAE6Xw-yeJA0Tunw";
+
+    const mockEq = vi.fn(() => ({
+      single: vi.fn(() =>
+        Promise.resolve({
+          data: { id: "some-uuid" },
+          error: null,
+        })
+      ),
+    }));
+
+    const mockSupabase = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: mockEq,
+        })),
+      })),
+    } as unknown as SupabaseClient;
+
+    await findChannelDbId(mockSupabase, youtubeChannelId);
+
+    expect(mockEq).toHaveBeenCalledWith("youtube_channel_id", youtubeChannelId);
+  });
+});

--- a/lib/supabase/channel-query.ts
+++ b/lib/supabase/channel-query.ts
@@ -1,0 +1,54 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { isUUID } from "@/lib/validation-utils";
+
+/**
+ * チャンネルIDの検索結果
+ */
+export type ChannelLookupResult =
+  | { found: true; channelDbId: string }
+  | { found: false };
+
+/**
+ * チャンネルIDからデータベースIDを解決する
+ *
+ * UUID形式の場合はデータベースIDとして直接使用し、
+ * YouTube ID形式の場合はyoutube_channel_idカラムで検索する。
+ *
+ * @param supabase Supabaseクライアント
+ * @param channelId UUID形式またはYouTubeチャンネルID
+ * @returns チャンネルのデータベースID、見つからない場合はnull
+ */
+export async function findChannelDbId(
+  supabase: SupabaseClient,
+  channelId: string
+): Promise<ChannelLookupResult> {
+  const isChannelUUID = isUUID(channelId);
+
+  if (isChannelUUID) {
+    // UUID形式の場合は直接データベースIDとして検索
+    const { data: channel, error: channelError } = await supabase
+      .from("channels")
+      .select("id")
+      .eq("id", channelId)
+      .single();
+
+    if (channelError || !channel) {
+      return { found: false };
+    }
+
+    return { found: true, channelDbId: channel.id };
+  }
+
+  // YouTube IDの場合はyoutube_channel_idで検索
+  const { data: channel, error: channelError } = await supabase
+    .from("channels")
+    .select("id")
+    .eq("youtube_channel_id", channelId)
+    .single();
+
+  if (channelError || !channel) {
+    return { found: false };
+  }
+
+  return { found: true, channelDbId: channel.id };
+}


### PR DESCRIPTION
## Summary

- `getChannelReviewsAction`（174行）から3つのヘルパー関数を抽出し、可読性・再利用性を向上
- `findChannelDbId()`: UUID/YouTube ID両対応のチャンネルDB ID解決（`lib/supabase/channel-query.ts`）
- `fetchUserHelpfulVotes()`: ユーザーの投票状態取得（`lib/review-helpers.ts`）
- `transformReviewsWithUser()`: Supabase JOINデータの型変換（`lib/review-helpers.ts`）
- `createReviewAction`でも`findChannelDbId()`を利用してコード重複を削減
- 全ヘルパーに対するユニットテストを追加（14テスト）

## Test plan

- [x] `npx tsc --noEmit` 型チェック通過
- [x] `npm run test:unit` 全194テスト通過（新規14テスト含む）
- [x] `npm run lint` エラーなし
- [x] `findChannelDbId` のUUID/YouTube ID判定テスト
- [x] `fetchUserHelpfulVotes` の投票取得テスト
- [x] `transformReviewsWithUser` の配列/単一オブジェクト変換テスト

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)