### PR TITLE
test: Improve test coverage to 88% (from 78%)

### DIFF
--- a/app/_actions/__tests__/list-channel.test.ts
+++ b/app/_actions/__tests__/list-channel.test.ts
@@ -2,10 +2,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   addChannelToListAction,
   removeChannelFromListAction,
+  getListChannelsAction,
+  searchChannelsForListAction,
 } from "../list-channel";
-import type { User } from "@supabase/supabase-js";
+import { createMockUser } from "./helpers/mock-user";
 
-// Mock dependencies
+// Supabase client mock
 const mockSupabase = {
   from: vi.fn(),
 };
@@ -22,52 +24,37 @@ vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
 
+vi.mock("@/lib/youtube/api", () => ({
+  searchChannels: vi.fn(),
+  getChannelDetails: vi.fn(),
+}));
+
+// ---------- addChannelToListAction ----------
+
 describe("addChannelToListAction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("should require authentication", async () => {
-    // Arrange
-    const { getUser } = await import("@/lib/auth");
-    vi.mocked(getUser).mockResolvedValue(null);
-
-    // Act
-    const result = await addChannelToListAction("list-id", "channel-id");
-
-    // Assert
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error).toBe("ログインが必要です");
-    }
-  });
-
   it("should add channel to list successfully", async () => {
     // Arrange
     const { getUser } = await import("@/lib/auth");
-    const mockUser = {
-      id: "user-id",
-      email: "test@example.com",
-      app_metadata: {},
-      user_metadata: {},
-      aud: "authenticated",
-      created_at: new Date().toISOString(),
-    } as User;
-    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(getUser).mockResolvedValue(createMockUser({ id: "user-123" }));
 
-    const mockFrom = vi.fn();
-    mockSupabase.from = mockFrom;
+    const listId = "list-001";
+    const channelId = "channel-001";
 
-    mockFrom.mockImplementation((table: string) => {
+    let fromCallCount = 0;
+
+    mockSupabase.from = vi.fn((table: string) => {
       if (table === "lists") {
-        // List ownership check
         return {
           select: vi.fn(() => ({
             eq: vi.fn(() => ({
               eq: vi.fn(() => ({
                 single: vi.fn(() =>
                   Promise.resolve({
-                    data: { id: "list-id" },
+                    data: { id: listId },
                     error: null,
                   })
                 ),
@@ -77,39 +64,45 @@ describe("addChannelToListAction", () => {
         };
       }
       if (table === "list_channels") {
-        // Check if channel already exists
-        const selectMock = vi.fn(() => ({
-          eq: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              single: vi.fn(() =>
-                Promise.resolve({
-                  data: null, // Not exists
-                  error: null,
-                })
-              ),
+        fromCallCount++;
+        // First call: duplicate check
+        if (fromCallCount === 1) {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  single: vi.fn(() =>
+                    Promise.resolve({
+                      data: null,
+                      error: { code: "PGRST116" },
+                    })
+                  ),
+                })),
+              })),
             })),
-          })),
-        }));
-
-        // Get max order_index
-        const orderMock = vi.fn(() => ({
-          limit: vi.fn(() => ({
-            single: vi.fn(() =>
-              Promise.resolve({
-                data: { order_index: 5 },
-                error: null,
-              })
-            ),
-          })),
-        }));
-
+          };
+        }
+        // Second call: max order_index
+        if (fromCallCount === 2) {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                order: vi.fn(() => ({
+                  limit: vi.fn(() => ({
+                    single: vi.fn(() =>
+                      Promise.resolve({
+                        data: { order_index: 3 },
+                        error: null,
+                      })
+                    ),
+                  })),
+                })),
+              })),
+            })),
+          };
+        }
+        // Third call: insert
         return {
-          select: vi.fn((columns: string) => {
-            if (columns === "id") return selectMock();
-            if (columns === "order_index")
-              return { eq: vi.fn(() => ({ order: orderMock })) };
-            return {};
-          }),
           insert: vi.fn(() =>
             Promise.resolve({
               error: null,
@@ -121,29 +114,36 @@ describe("addChannelToListAction", () => {
     });
 
     // Act
-    const result = await addChannelToListAction("list-id", "channel-id");
+    const result = await addChannelToListAction(listId, channelId);
 
     // Assert
     expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBeUndefined();
+    }
   });
 
-  it("should reject if user does not own the list", async () => {
+  it("should return error when user is not authenticated", async () => {
     // Arrange
     const { getUser } = await import("@/lib/auth");
-    const mockUser = {
-      id: "user-id",
-      email: "test@example.com",
-      app_metadata: {},
-      user_metadata: {},
-      aud: "authenticated",
-      created_at: new Date().toISOString(),
-    } as User;
-    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(getUser).mockResolvedValue(null);
 
-    const mockFrom = vi.fn();
-    mockSupabase.from = mockFrom;
+    // Act
+    const result = await addChannelToListAction("list-001", "channel-001");
 
-    mockFrom.mockImplementation((table: string) => {
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("ログインが必要です");
+    }
+  });
+
+  it("should return error when list not found or user lacks permission", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue(createMockUser({ id: "user-123" }));
+
+    mockSupabase.from = vi.fn((table: string) => {
       if (table === "lists") {
         return {
           select: vi.fn(() => ({
@@ -152,7 +152,7 @@ describe("addChannelToListAction", () => {
                 single: vi.fn(() =>
                   Promise.resolve({
                     data: null,
-                    error: { message: "Not found" },
+                    error: { code: "PGRST116", message: "Not found" },
                   })
                 ),
               })),
@@ -164,7 +164,7 @@ describe("addChannelToListAction", () => {
     });
 
     // Act
-    const result = await addChannelToListAction("list-id", "channel-id");
+    const result = await addChannelToListAction("list-999", "channel-001");
 
     // Assert
     expect(result.success).toBe(false);
@@ -173,23 +173,15 @@ describe("addChannelToListAction", () => {
     }
   });
 
-  it("should reject duplicate channel addition", async () => {
+  it("should return error when channel is already in list (duplicate)", async () => {
     // Arrange
     const { getUser } = await import("@/lib/auth");
-    const mockUser = {
-      id: "user-id",
-      email: "test@example.com",
-      app_metadata: {},
-      user_metadata: {},
-      aud: "authenticated",
-      created_at: new Date().toISOString(),
-    } as User;
-    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(getUser).mockResolvedValue(createMockUser({ id: "user-123" }));
 
-    const mockFrom = vi.fn();
-    mockSupabase.from = mockFrom;
+    const listId = "list-001";
+    const channelId = "channel-001";
 
-    mockFrom.mockImplementation((table: string) => {
+    mockSupabase.from = vi.fn((table: string) => {
       if (table === "lists") {
         return {
           select: vi.fn(() => ({
@@ -197,7 +189,7 @@ describe("addChannelToListAction", () => {
               eq: vi.fn(() => ({
                 single: vi.fn(() =>
                   Promise.resolve({
-                    data: { id: "list-id" },
+                    data: { id: listId },
                     error: null,
                   })
                 ),
@@ -213,7 +205,7 @@ describe("addChannelToListAction", () => {
               eq: vi.fn(() => ({
                 single: vi.fn(() =>
                   Promise.resolve({
-                    data: { id: "existing-id" }, // Already exists
+                    data: { id: "existing-entry" },
                     error: null,
                   })
                 ),
@@ -226,7 +218,7 @@ describe("addChannelToListAction", () => {
     });
 
     // Act
-    const result = await addChannelToListAction("list-id", "channel-id");
+    const result = await addChannelToListAction(listId, channelId);
 
     // Assert
     expect(result.success).toBe(false);
@@ -234,45 +226,18 @@ describe("addChannelToListAction", () => {
       expect(result.error).toBe("このチャンネルは既にリストに追加されています");
     }
   });
-});
 
-describe("removeChannelFromListAction", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("should require authentication", async () => {
+  it("should return error when insert fails", async () => {
     // Arrange
     const { getUser } = await import("@/lib/auth");
-    vi.mocked(getUser).mockResolvedValue(null);
+    vi.mocked(getUser).mockResolvedValue(createMockUser({ id: "user-123" }));
 
-    // Act
-    const result = await removeChannelFromListAction("list-id", "channel-id");
+    const listId = "list-001";
+    const channelId = "channel-001";
 
-    // Assert
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error).toBe("ログインが必要です");
-    }
-  });
+    let fromCallCount = 0;
 
-  it("should remove channel from list successfully", async () => {
-    // Arrange
-    const { getUser } = await import("@/lib/auth");
-    const mockUser = {
-      id: "user-id",
-      email: "test@example.com",
-      app_metadata: {},
-      user_metadata: {},
-      aud: "authenticated",
-      created_at: new Date().toISOString(),
-    } as User;
-    vi.mocked(getUser).mockResolvedValue(mockUser);
-
-    const mockFrom = vi.fn();
-    mockSupabase.from = mockFrom;
-
-    mockFrom.mockImplementation((table: string) => {
+    mockSupabase.from = vi.fn((table: string) => {
       if (table === "lists") {
         return {
           select: vi.fn(() => ({
@@ -280,7 +245,192 @@ describe("removeChannelFromListAction", () => {
               eq: vi.fn(() => ({
                 single: vi.fn(() =>
                   Promise.resolve({
-                    data: { id: "list-id" },
+                    data: { id: listId },
+                    error: null,
+                  })
+                ),
+              })),
+            })),
+          })),
+        };
+      }
+      if (table === "list_channels") {
+        fromCallCount++;
+        // First call: duplicate check - no existing
+        if (fromCallCount === 1) {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  single: vi.fn(() =>
+                    Promise.resolve({
+                      data: null,
+                      error: { code: "PGRST116" },
+                    })
+                  ),
+                })),
+              })),
+            })),
+          };
+        }
+        // Second call: max order_index
+        if (fromCallCount === 2) {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                order: vi.fn(() => ({
+                  limit: vi.fn(() => ({
+                    single: vi.fn(() =>
+                      Promise.resolve({
+                        data: null,
+                        error: null,
+                      })
+                    ),
+                  })),
+                })),
+              })),
+            })),
+          };
+        }
+        // Third call: insert fails
+        return {
+          insert: vi.fn(() =>
+            Promise.resolve({
+              error: { message: "Insert failed", code: "23503" },
+            })
+          ),
+        };
+      }
+      return {};
+    });
+
+    // Act
+    const result = await addChannelToListAction(listId, channelId);
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("チャンネルの追加に失敗しました");
+    }
+  });
+
+  it("should use order_index 1 when no existing channels in list", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue(createMockUser({ id: "user-123" }));
+
+    const listId = "list-001";
+    const channelId = "channel-001";
+
+    let fromCallCount = 0;
+    const mockInsert = vi.fn(() =>
+      Promise.resolve({
+        error: null,
+      })
+    );
+
+    mockSupabase.from = vi.fn((table: string) => {
+      if (table === "lists") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn(() =>
+                  Promise.resolve({
+                    data: { id: listId },
+                    error: null,
+                  })
+                ),
+              })),
+            })),
+          })),
+        };
+      }
+      if (table === "list_channels") {
+        fromCallCount++;
+        // First call: duplicate check - no existing
+        if (fromCallCount === 1) {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  single: vi.fn(() =>
+                    Promise.resolve({
+                      data: null,
+                      error: { code: "PGRST116" },
+                    })
+                  ),
+                })),
+              })),
+            })),
+          };
+        }
+        // Second call: max order_index - empty list returns null
+        if (fromCallCount === 2) {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                order: vi.fn(() => ({
+                  limit: vi.fn(() => ({
+                    single: vi.fn(() =>
+                      Promise.resolve({
+                        data: null,
+                        error: null,
+                      })
+                    ),
+                  })),
+                })),
+              })),
+            })),
+          };
+        }
+        // Third call: insert with order_index = 1
+        return {
+          insert: mockInsert,
+        };
+      }
+      return {};
+    });
+
+    // Act
+    const result = await addChannelToListAction(listId, channelId);
+
+    // Assert
+    expect(result.success).toBe(true);
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        list_id: listId,
+        channel_id: channelId,
+        order_index: 1,
+      })
+    );
+  });
+});
+
+// ---------- removeChannelFromListAction ----------
+
+describe("removeChannelFromListAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should remove channel from list successfully", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue(createMockUser({ id: "user-123" }));
+
+    const listId = "list-001";
+    const channelId = "channel-001";
+
+    mockSupabase.from = vi.fn((table: string) => {
+      if (table === "lists") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn(() =>
+                  Promise.resolve({
+                    data: { id: listId },
                     error: null,
                   })
                 ),
@@ -306,9 +456,538 @@ describe("removeChannelFromListAction", () => {
     });
 
     // Act
-    const result = await removeChannelFromListAction("list-id", "channel-id");
+    const result = await removeChannelFromListAction(listId, channelId);
 
     // Assert
     expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBeUndefined();
+    }
+  });
+
+  it("should return error when user is not authenticated", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue(null);
+
+    // Act
+    const result = await removeChannelFromListAction("list-001", "channel-001");
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("ログインが必要です");
+    }
+  });
+
+  it("should return error when list not found or user lacks permission", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue(createMockUser({ id: "user-123" }));
+
+    mockSupabase.from = vi.fn((table: string) => {
+      if (table === "lists") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn(() =>
+                  Promise.resolve({
+                    data: null,
+                    error: { code: "PGRST116", message: "Not found" },
+                  })
+                ),
+              })),
+            })),
+          })),
+        };
+      }
+      return {};
+    });
+
+    // Act
+    const result = await removeChannelFromListAction("list-999", "channel-001");
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("このリストを編集する権限がありません");
+    }
+  });
+
+  it("should return error when delete operation fails", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue(createMockUser({ id: "user-123" }));
+
+    const listId = "list-001";
+    const channelId = "channel-001";
+
+    mockSupabase.from = vi.fn((table: string) => {
+      if (table === "lists") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                single: vi.fn(() =>
+                  Promise.resolve({
+                    data: { id: listId },
+                    error: null,
+                  })
+                ),
+              })),
+            })),
+          })),
+        };
+      }
+      if (table === "list_channels") {
+        return {
+          delete: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() =>
+                Promise.resolve({
+                  error: { message: "Delete failed" },
+                })
+              ),
+            })),
+          })),
+        };
+      }
+      return {};
+    });
+
+    // Act
+    const result = await removeChannelFromListAction(listId, channelId);
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("チャンネルの削除に失敗しました");
+    }
+  });
+});
+
+// ---------- getListChannelsAction ----------
+
+describe("getListChannelsAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should get list channels successfully with data", async () => {
+    // Arrange
+    const listId = "list-001";
+    const mockData = [
+      {
+        id: "lc-001",
+        order_index: 1,
+        created_at: "2024-01-01T00:00:00Z",
+        channel: {
+          id: "ch-001",
+          youtube_channel_id: "UC123",
+          title: "Test Channel",
+          description: "A test channel",
+          thumbnail_url: "https://example.com/thumb.jpg",
+          subscriber_count: 10000,
+          video_count: 100,
+        },
+      },
+      {
+        id: "lc-002",
+        order_index: 2,
+        created_at: "2024-01-02T00:00:00Z",
+        channel: {
+          id: "ch-002",
+          youtube_channel_id: "UC456",
+          title: "Another Channel",
+          description: null,
+          thumbnail_url: "https://example.com/thumb2.jpg",
+          subscriber_count: 5000,
+          video_count: 50,
+        },
+      },
+    ];
+
+    mockSupabase.from = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          order: vi.fn(() =>
+            Promise.resolve({
+              data: mockData,
+              error: null,
+            })
+          ),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await getListChannelsAction(listId);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0]?.channel.title).toBe("Test Channel");
+      expect(result.data[1]?.channel.title).toBe("Another Channel");
+    }
+  });
+
+  it("should return empty array when list has no channels", async () => {
+    // Arrange
+    const listId = "list-001";
+
+    mockSupabase.from = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          order: vi.fn(() =>
+            Promise.resolve({
+              data: [],
+              error: null,
+            })
+          ),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await getListChannelsAction(listId);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual([]);
+    }
+  });
+
+  it("should return error when query fails", async () => {
+    // Arrange
+    const listId = "list-001";
+
+    mockSupabase.from = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          order: vi.fn(() =>
+            Promise.resolve({
+              data: null,
+              error: { message: "Query failed" },
+            })
+          ),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await getListChannelsAction(listId);
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("チャンネル一覧の取得に失敗しました");
+    }
+  });
+
+  it("should handle array channel in JOIN results", async () => {
+    // Arrange
+    const listId = "list-001";
+    const mockData = [
+      {
+        id: "lc-001",
+        order_index: 1,
+        created_at: "2024-01-01T00:00:00Z",
+        channel: [
+          {
+            id: "ch-001",
+            youtube_channel_id: "UC123",
+            title: "Array Channel",
+            description: "desc",
+            thumbnail_url: "https://example.com/thumb.jpg",
+            subscriber_count: 10000,
+            video_count: 100,
+          },
+        ],
+      },
+    ];
+
+    mockSupabase.from = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          order: vi.fn(() =>
+            Promise.resolve({
+              data: mockData,
+              error: null,
+            })
+          ),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await getListChannelsAction(listId);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]?.channel.title).toBe("Array Channel");
+      expect(Array.isArray(result.data[0]?.channel)).toBe(false);
+    }
+  });
+});
+
+// ---------- searchChannelsForListAction ----------
+
+describe("searchChannelsForListAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should search channels and upsert to database successfully", async () => {
+    // Arrange
+    const { searchChannels, getChannelDetails } =
+      await import("@/lib/youtube/api");
+
+    const mockYoutubeResults = [
+      {
+        youtubeChannelId: "UC111",
+        title: "Channel One",
+        description: "First channel",
+        thumbnailUrl: "https://example.com/thumb1.jpg",
+      },
+      {
+        youtubeChannelId: "UC222",
+        title: "Channel Two",
+        description: "Second channel",
+        thumbnailUrl: "https://example.com/thumb2.jpg",
+      },
+    ];
+
+    vi.mocked(searchChannels).mockResolvedValue(mockYoutubeResults);
+
+    vi.mocked(getChannelDetails)
+      .mockResolvedValueOnce({
+        youtubeChannelId: "UC111",
+        title: "Channel One",
+        description: "First channel",
+        thumbnailUrl: "https://example.com/thumb1.jpg",
+        subscriberCount: 50000,
+        videoCount: 200,
+        viewCount: 1000000,
+      })
+      .mockResolvedValueOnce({
+        youtubeChannelId: "UC222",
+        title: "Channel Two",
+        description: "Second channel",
+        thumbnailUrl: "https://example.com/thumb2.jpg",
+        subscriberCount: 30000,
+        videoCount: 100,
+        viewCount: 500000,
+      });
+
+    const upsertedChannels = [
+      {
+        id: "db-ch-001",
+        youtube_channel_id: "UC111",
+        title: "Channel One",
+        thumbnail_url: "https://example.com/thumb1.jpg",
+        subscriber_count: 50000,
+      },
+      {
+        id: "db-ch-002",
+        youtube_channel_id: "UC222",
+        title: "Channel Two",
+        thumbnail_url: "https://example.com/thumb2.jpg",
+        subscriber_count: 30000,
+      },
+    ];
+
+    let upsertCallCount = 0;
+
+    mockSupabase.from = vi.fn(() => ({
+      upsert: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn(() => {
+            const channel = upsertedChannels[upsertCallCount];
+            upsertCallCount++;
+            return Promise.resolve({
+              data: channel,
+              error: null,
+            });
+          }),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await searchChannelsForListAction("test query");
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0]?.youtube_channel_id).toBe("UC111");
+      expect(result.data[1]?.youtube_channel_id).toBe("UC222");
+    }
+    expect(searchChannels).toHaveBeenCalledWith("test query", 10);
+  });
+
+  it("should return empty array when no YouTube results found", async () => {
+    // Arrange
+    const { searchChannels } = await import("@/lib/youtube/api");
+    vi.mocked(searchChannels).mockResolvedValue([]);
+
+    // Act
+    const result = await searchChannelsForListAction("nonexistent channel xyz");
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual([]);
+    }
+  });
+
+  it("should skip individual channels on upsert error and continue", async () => {
+    // Arrange
+    const { searchChannels, getChannelDetails } =
+      await import("@/lib/youtube/api");
+
+    const mockYoutubeResults = [
+      {
+        youtubeChannelId: "UC111",
+        title: "Channel One",
+        description: "First",
+        thumbnailUrl: "https://example.com/thumb1.jpg",
+      },
+      {
+        youtubeChannelId: "UC222",
+        title: "Channel Two",
+        description: "Second",
+        thumbnailUrl: "https://example.com/thumb2.jpg",
+      },
+      {
+        youtubeChannelId: "UC333",
+        title: "Channel Three",
+        description: "Third",
+        thumbnailUrl: "https://example.com/thumb3.jpg",
+      },
+    ];
+
+    vi.mocked(searchChannels).mockResolvedValue(mockYoutubeResults);
+
+    vi.mocked(getChannelDetails)
+      .mockResolvedValueOnce({
+        youtubeChannelId: "UC111",
+        title: "Channel One",
+        description: "First",
+        thumbnailUrl: "https://example.com/thumb1.jpg",
+        subscriberCount: 50000,
+        videoCount: 200,
+        viewCount: 1000000,
+      })
+      .mockResolvedValueOnce({
+        youtubeChannelId: "UC222",
+        title: "Channel Two",
+        description: "Second",
+        thumbnailUrl: "https://example.com/thumb2.jpg",
+        subscriberCount: 30000,
+        videoCount: 100,
+        viewCount: 500000,
+      })
+      .mockResolvedValueOnce({
+        youtubeChannelId: "UC333",
+        title: "Channel Three",
+        description: "Third",
+        thumbnailUrl: "https://example.com/thumb3.jpg",
+        subscriberCount: 20000,
+        videoCount: 50,
+        viewCount: 250000,
+      });
+
+    let upsertCallCount = 0;
+
+    mockSupabase.from = vi.fn(() => ({
+      upsert: vi.fn(() => ({
+        select: vi.fn(() => ({
+          single: vi.fn(() => {
+            upsertCallCount++;
+            // Second channel upsert fails
+            if (upsertCallCount === 2) {
+              return Promise.resolve({
+                data: null,
+                error: { message: "Upsert failed", code: "23505" },
+              });
+            }
+            if (upsertCallCount === 1) {
+              return Promise.resolve({
+                data: {
+                  id: "db-ch-001",
+                  youtube_channel_id: "UC111",
+                  title: "Channel One",
+                  thumbnail_url: "https://example.com/thumb1.jpg",
+                  subscriber_count: 50000,
+                },
+                error: null,
+              });
+            }
+            // Third succeeds
+            return Promise.resolve({
+              data: {
+                id: "db-ch-003",
+                youtube_channel_id: "UC333",
+                title: "Channel Three",
+                thumbnail_url: "https://example.com/thumb3.jpg",
+                subscriber_count: 20000,
+              },
+              error: null,
+            });
+          }),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await searchChannelsForListAction("test query");
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0]?.youtube_channel_id).toBe("UC111");
+      expect(result.data[1]?.youtube_channel_id).toBe("UC333");
+    }
+  });
+
+  it("should return quota exceeded error when YouTube API quota is exhausted", async () => {
+    // Arrange
+    const { searchChannels } = await import("@/lib/youtube/api");
+    vi.mocked(searchChannels).mockRejectedValue({ code: "QUOTA_EXCEEDED" });
+
+    // Act
+    const result = await searchChannelsForListAction("test query");
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe(
+        "YouTube APIのクォータを超過しました。しばらくしてから再度お試しください。"
+      );
+    }
+  });
+
+  it("should return rate limit error when too many requests", async () => {
+    // Arrange
+    const { searchChannels } = await import("@/lib/youtube/api");
+    vi.mocked(searchChannels).mockRejectedValue({ code: "RATE_LIMIT" });
+
+    // Act
+    const result = await searchChannelsForListAction("test query");
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe(
+        "リクエスト制限に達しました。しばらくしてから再度お試しください。"
+      );
+    }
   });
 });

--- a/app/_actions/__tests__/list.test.ts
+++ b/app/_actions/__tests__/list.test.ts
@@ -3,8 +3,9 @@ import {
   createMyListAction,
   updateMyListAction,
   deleteMyListAction,
+  getMyListsAction,
 } from "../list";
-import type { User } from "@supabase/supabase-js";
+import { createMockUser } from "./helpers/mock-user";
 
 // Mock dependencies
 const mockSupabase = {
@@ -50,14 +51,7 @@ describe("createMyListAction", () => {
   it("should create list successfully", async () => {
     // Arrange
     const { getUser } = await import("@/lib/auth");
-    const mockUser = {
-      id: "user-id",
-      email: "test@example.com",
-      app_metadata: {},
-      user_metadata: {},
-      aud: "authenticated",
-      created_at: new Date().toISOString(),
-    } as User;
+    const mockUser = createMockUser({ id: "user-id" });
     vi.mocked(getUser).mockResolvedValue(mockUser);
 
     const mockList = {
@@ -97,14 +91,7 @@ describe("createMyListAction", () => {
   it("should reject list title longer than 50 characters", async () => {
     // Arrange
     const { getUser } = await import("@/lib/auth");
-    const mockUser = {
-      id: "user-id",
-      email: "test@example.com",
-      app_metadata: {},
-      user_metadata: {},
-      aud: "authenticated",
-      created_at: new Date().toISOString(),
-    } as User;
+    const mockUser = createMockUser({ id: "user-id" });
     vi.mocked(getUser).mockResolvedValue(mockUser);
 
     // Act
@@ -144,15 +131,18 @@ describe("updateMyListAction", () => {
   it("should update list successfully", async () => {
     // Arrange
     const { getUser } = await import("@/lib/auth");
-    const mockUser = {
-      id: "user-id",
-      email: "test@example.com",
-      app_metadata: {},
-      user_metadata: {},
-      aud: "authenticated",
-      created_at: new Date().toISOString(),
-    } as User;
+    const mockUser = createMockUser({ id: "user-id" });
     vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    const mockUpdatedList = {
+      id: "list-id",
+      user_id: "user-id",
+      title: "Updated List",
+      description: "Updated description",
+      is_public: false,
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-02T00:00:00Z",
+    };
 
     mockSupabase.from = vi.fn(() => ({
       update: vi.fn(() => ({
@@ -160,10 +150,7 @@ describe("updateMyListAction", () => {
           select: vi.fn(() => ({
             single: vi.fn(() =>
               Promise.resolve({
-                data: {
-                  id: "list-id",
-                  title: "Updated List",
-                },
+                data: mockUpdatedList,
                 error: null,
               })
             ),
@@ -175,23 +162,21 @@ describe("updateMyListAction", () => {
     // Act
     const result = await updateMyListAction("list-id", {
       title: "Updated List",
+      description: "Updated description",
+      isPublic: false,
     });
 
     // Assert
     expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual(mockUpdatedList);
+    }
   });
 
-  it("should reject update if user does not own the list", async () => {
+  it("should reject update if user does not own the list (PGRST116)", async () => {
     // Arrange
     const { getUser } = await import("@/lib/auth");
-    const mockUser = {
-      id: "user-id",
-      email: "test@example.com",
-      app_metadata: {},
-      user_metadata: {},
-      aud: "authenticated",
-      created_at: new Date().toISOString(),
-    } as User;
+    const mockUser = createMockUser({ id: "user-id" });
     vi.mocked(getUser).mockResolvedValue(mockUser);
 
     mockSupabase.from = vi.fn(() => ({
@@ -220,6 +205,171 @@ describe("updateMyListAction", () => {
       expect(result.error).toBe("このリストを編集する権限がありません");
     }
   });
+
+  it("should handle general supabase error", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = createMockUser({ id: "user-id" });
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    mockSupabase.from = vi.fn(() => ({
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn(() =>
+              Promise.resolve({
+                data: null,
+                error: {
+                  code: "UNKNOWN",
+                  message: "Database connection error",
+                },
+              })
+            ),
+          })),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await updateMyListAction("list-id", {
+      title: "Updated List",
+    });
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("リストの更新に失敗しました");
+    }
+  });
+
+  it("should update only title (partial update)", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = createMockUser({ id: "user-id" });
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    const mockUpdatedList = {
+      id: "list-id",
+      user_id: "user-id",
+      title: "New Title Only",
+      description: "Original description",
+      is_public: true,
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-02T00:00:00Z",
+    };
+
+    mockSupabase.from = vi.fn(() => ({
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn(() =>
+              Promise.resolve({
+                data: mockUpdatedList,
+                error: null,
+              })
+            ),
+          })),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await updateMyListAction("list-id", {
+      title: "New Title Only",
+    });
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.title).toBe("New Title Only");
+    }
+  });
+
+  it("should update only description (partial update)", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = createMockUser({ id: "user-id" });
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    const mockUpdatedList = {
+      id: "list-id",
+      user_id: "user-id",
+      title: "Original Title",
+      description: "New Description Only",
+      is_public: true,
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-02T00:00:00Z",
+    };
+
+    mockSupabase.from = vi.fn(() => ({
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn(() =>
+              Promise.resolve({
+                data: mockUpdatedList,
+                error: null,
+              })
+            ),
+          })),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await updateMyListAction("list-id", {
+      description: "New Description Only",
+    });
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.description).toBe("New Description Only");
+    }
+  });
+
+  it("should update only isPublic (partial update)", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = createMockUser({ id: "user-id" });
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    const mockUpdatedList = {
+      id: "list-id",
+      user_id: "user-id",
+      title: "Original Title",
+      description: "Original description",
+      is_public: false,
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-02T00:00:00Z",
+    };
+
+    mockSupabase.from = vi.fn(() => ({
+      update: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn(() =>
+              Promise.resolve({
+                data: mockUpdatedList,
+                error: null,
+              })
+            ),
+          })),
+        })),
+      })),
+    }));
+
+    // Act
+    const result = await updateMyListAction("list-id", {
+      isPublic: false,
+    });
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.is_public).toBe(false);
+    }
+  });
 });
 
 describe("deleteMyListAction", () => {
@@ -245,14 +395,7 @@ describe("deleteMyListAction", () => {
   it("should delete list successfully", async () => {
     // Arrange
     const { getUser } = await import("@/lib/auth");
-    const mockUser = {
-      id: "user-id",
-      email: "test@example.com",
-      app_metadata: {},
-      user_metadata: {},
-      aud: "authenticated",
-      created_at: new Date().toISOString(),
-    } as User;
+    const mockUser = createMockUser({ id: "user-id" });
     vi.mocked(getUser).mockResolvedValue(mockUser);
 
     mockSupabase.from = vi.fn(() => ({
@@ -270,5 +413,286 @@ describe("deleteMyListAction", () => {
 
     // Assert
     expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBeUndefined();
+    }
+  });
+
+  it("should handle delete error", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = createMockUser({ id: "user-id" });
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    mockSupabase.from = vi.fn(() => ({
+      delete: vi.fn(() => ({
+        eq: vi.fn(() =>
+          Promise.resolve({
+            error: { code: "UNKNOWN", message: "Delete failed" },
+          })
+        ),
+      })),
+    }));
+
+    // Act
+    const result = await deleteMyListAction("list-id");
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("リストの削除に失敗しました");
+    }
+  });
+});
+
+describe("getMyListsAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should require authentication", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue(null);
+
+    // Act
+    const result = await getMyListsAction();
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("ログインが必要です");
+    }
+  });
+
+  it("should get lists with pagination successfully", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = createMockUser({ id: "user-id" });
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    const mockLists = [
+      {
+        id: "list-1",
+        user_id: "user-id",
+        title: "List 1",
+        description: "Description 1",
+        is_public: true,
+        created_at: "2024-01-02T00:00:00Z",
+        updated_at: "2024-01-02T00:00:00Z",
+      },
+      {
+        id: "list-2",
+        user_id: "user-id",
+        title: "List 2",
+        description: null,
+        is_public: false,
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+      },
+    ];
+
+    // Mock for the data query (chained: select -> eq -> order -> range)
+    const mockRange = vi.fn(() =>
+      Promise.resolve({ data: mockLists, error: null })
+    );
+    const mockOrder = vi.fn(() => ({ range: mockRange }));
+    const mockEqData = vi.fn(() => ({ order: mockOrder }));
+    const mockSelectData = vi.fn(() => ({ eq: mockEqData }));
+
+    // Mock for the count query (chained: select -> eq)
+    const mockEqCount = vi.fn(() => Promise.resolve({ count: 2, error: null }));
+    const mockSelectCount = vi.fn(() => ({ eq: mockEqCount }));
+
+    let callCount = 0;
+    mockSupabase.from = vi.fn(() => {
+      callCount++;
+      if (callCount === 1) {
+        return { select: mockSelectData };
+      }
+      return { select: mockSelectCount };
+    });
+
+    // Act
+    const result = await getMyListsAction(1, 20);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.lists).toEqual(mockLists);
+      expect(result.data.pagination).toEqual({
+        page: 1,
+        limit: 20,
+        total: 2,
+        totalPages: 1,
+      });
+    }
+  });
+
+  it("should handle custom page and limit parameters", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = createMockUser({ id: "user-id" });
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    const mockLists = [
+      {
+        id: "list-3",
+        user_id: "user-id",
+        title: "List 3",
+        description: null,
+        is_public: false,
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+      },
+    ];
+
+    const mockRange = vi.fn(() =>
+      Promise.resolve({ data: mockLists, error: null })
+    );
+    const mockOrder = vi.fn(() => ({ range: mockRange }));
+    const mockEqData = vi.fn(() => ({ order: mockOrder }));
+    const mockSelectData = vi.fn(() => ({ eq: mockEqData }));
+
+    const mockEqCount = vi.fn(() => Promise.resolve({ count: 5, error: null }));
+    const mockSelectCount = vi.fn(() => ({ eq: mockEqCount }));
+
+    let callCount = 0;
+    mockSupabase.from = vi.fn(() => {
+      callCount++;
+      if (callCount === 1) {
+        return { select: mockSelectData };
+      }
+      return { select: mockSelectCount };
+    });
+
+    // Act
+    const result = await getMyListsAction(3, 2);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.pagination).toEqual({
+        page: 3,
+        limit: 2,
+        total: 5,
+        totalPages: 3,
+      });
+    }
+  });
+
+  it("should handle supabase error on data query", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = createMockUser({ id: "user-id" });
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    const mockRange = vi.fn(() =>
+      Promise.resolve({
+        data: null,
+        error: { code: "UNKNOWN", message: "Query failed" },
+      })
+    );
+    const mockOrder = vi.fn(() => ({ range: mockRange }));
+    const mockEqData = vi.fn(() => ({ order: mockOrder }));
+    const mockSelectData = vi.fn(() => ({ eq: mockEqData }));
+
+    const mockEqCount = vi.fn(() => Promise.resolve({ count: 0, error: null }));
+    const mockSelectCount = vi.fn(() => ({ eq: mockEqCount }));
+
+    let callCount = 0;
+    mockSupabase.from = vi.fn(() => {
+      callCount++;
+      if (callCount === 1) {
+        return { select: mockSelectData };
+      }
+      return { select: mockSelectCount };
+    });
+
+    // Act
+    const result = await getMyListsAction();
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("リストの取得に失敗しました");
+    }
+  });
+
+  it("should handle supabase error on count query", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = createMockUser({ id: "user-id" });
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    const mockRange = vi.fn(() => Promise.resolve({ data: [], error: null }));
+    const mockOrder = vi.fn(() => ({ range: mockRange }));
+    const mockEqData = vi.fn(() => ({ order: mockOrder }));
+    const mockSelectData = vi.fn(() => ({ eq: mockEqData }));
+
+    const mockEqCount = vi.fn(() =>
+      Promise.resolve({
+        count: null,
+        error: { code: "UNKNOWN", message: "Count failed" },
+      })
+    );
+    const mockSelectCount = vi.fn(() => ({ eq: mockEqCount }));
+
+    let callCount = 0;
+    mockSupabase.from = vi.fn(() => {
+      callCount++;
+      if (callCount === 1) {
+        return { select: mockSelectData };
+      }
+      return { select: mockSelectCount };
+    });
+
+    // Act
+    const result = await getMyListsAction();
+
+    // Assert
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toBe("リストの取得に失敗しました");
+    }
+  });
+
+  it("should return empty list when user has no lists", async () => {
+    // Arrange
+    const { getUser } = await import("@/lib/auth");
+    const mockUser = createMockUser({ id: "user-id" });
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+
+    const mockRange = vi.fn(() => Promise.resolve({ data: [], error: null }));
+    const mockOrder = vi.fn(() => ({ range: mockRange }));
+    const mockEqData = vi.fn(() => ({ order: mockOrder }));
+    const mockSelectData = vi.fn(() => ({ eq: mockEqData }));
+
+    const mockEqCount = vi.fn(() => Promise.resolve({ count: 0, error: null }));
+    const mockSelectCount = vi.fn(() => ({ eq: mockEqCount }));
+
+    let callCount = 0;
+    mockSupabase.from = vi.fn(() => {
+      callCount++;
+      if (callCount === 1) {
+        return { select: mockSelectData };
+      }
+      return { select: mockSelectCount };
+    });
+
+    // Act
+    const result = await getMyListsAction();
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.lists).toEqual([]);
+      expect(result.data.pagination).toEqual({
+        page: 1,
+        limit: 20,
+        total: 0,
+        totalPages: 0,
+      });
+    }
   });
 });

--- a/lib/cache/__tests__/redis.test.ts
+++ b/lib/cache/__tests__/redis.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Reset modules before each test to ensure clean singleton state
+beforeEach(() => {
+  vi.resetModules();
+  vi.unstubAllEnvs();
+});
+
+describe("getRedisClient", () => {
+  it("should return null when env vars are not set", async () => {
+    vi.stubEnv("UPSTASH_REDIS_REST_URL", "");
+    vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "");
+
+    const { getRedisClient } = await import("../redis");
+    const client = getRedisClient();
+    expect(client).toBeNull();
+  });
+
+  it("should return null when URL is missing", async () => {
+    vi.stubEnv("UPSTASH_REDIS_REST_URL", "");
+    vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "test-token");
+
+    const { getRedisClient } = await import("../redis");
+    const client = getRedisClient();
+    expect(client).toBeNull();
+  });
+
+  it("should return null when TOKEN is missing", async () => {
+    vi.stubEnv("UPSTASH_REDIS_REST_URL", "https://test.upstash.io");
+    vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "");
+
+    const { getRedisClient } = await import("../redis");
+    const client = getRedisClient();
+    expect(client).toBeNull();
+  });
+
+  it("should return Redis client when env vars are set", async () => {
+    vi.stubEnv("UPSTASH_REDIS_REST_URL", "https://test.upstash.io");
+    vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "test-token-value");
+
+    const { getRedisClient } = await import("../redis");
+    const client = getRedisClient();
+    expect(client).not.toBeNull();
+  });
+
+  it("should return same instance on subsequent calls (singleton)", async () => {
+    vi.stubEnv("UPSTASH_REDIS_REST_URL", "https://test.upstash.io");
+    vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "test-token-value");
+
+    const { getRedisClient } = await import("../redis");
+    const client1 = getRedisClient();
+    const client2 = getRedisClient();
+    expect(client1).toBe(client2);
+  });
+});
+
+describe("isCacheEnabled", () => {
+  it("should return false when env vars are not set", async () => {
+    vi.stubEnv("UPSTASH_REDIS_REST_URL", "");
+    vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "");
+
+    const { isCacheEnabled } = await import("../redis");
+    expect(isCacheEnabled()).toBe(false);
+  });
+
+  it("should return true when env vars are set", async () => {
+    vi.stubEnv("UPSTASH_REDIS_REST_URL", "https://test.upstash.io");
+    vi.stubEnv("UPSTASH_REDIS_REST_TOKEN", "test-token-value");
+
+    const { isCacheEnabled } = await import("../redis");
+    expect(isCacheEnabled()).toBe(true);
+  });
+});
+
+describe("CACHE_KEYS", () => {
+  it("should have expected cache key constants", async () => {
+    const { CACHE_KEYS } = await import("../redis");
+    expect(CACHE_KEYS.CHANNEL_INFO).toBe("channel:info");
+    expect(CACHE_KEYS.CHANNEL_STATS).toBe("channel:stats");
+    expect(CACHE_KEYS.RANKING_TOTAL).toBe("ranking:total");
+    expect(CACHE_KEYS.RANKING_CATEGORY).toBe("ranking:category");
+    expect(CACHE_KEYS.REVIEW_STATS).toBe("review:stats");
+  });
+});
+
+describe("CACHE_TTL", () => {
+  it("should have expected TTL values in seconds", async () => {
+    const { CACHE_TTL } = await import("../redis");
+    expect(CACHE_TTL.CHANNEL_INFO).toBe(60 * 60 * 24); // 24 hours
+    expect(CACHE_TTL.CHANNEL_STATS).toBe(60 * 60); // 1 hour
+    expect(CACHE_TTL.RANKING).toBe(60 * 15); // 15 minutes
+    expect(CACHE_TTL.REVIEW_STATS).toBe(60 * 5); // 5 minutes
+  });
+});

--- a/lib/constants/__tests__/categories.test.ts
+++ b/lib/constants/__tests__/categories.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  CATEGORIES,
+  getCategoryBySlug,
+  getAllCategorySlugs,
+} from "../categories";
+
+describe("CATEGORIES", () => {
+  it("should have at least one category", () => {
+    expect(CATEGORIES.length).toBeGreaterThan(0);
+  });
+
+  it("should have unique slugs", () => {
+    const slugs = CATEGORIES.map((c) => c.slug);
+    const uniqueSlugs = new Set(slugs);
+    expect(uniqueSlugs.size).toBe(slugs.length);
+  });
+
+  it("should have required properties for each category", () => {
+    for (const cat of CATEGORIES) {
+      expect(cat.slug).toBeDefined();
+      expect(cat.name).toBeDefined();
+      expect(cat.icon).toBeDefined();
+      expect(cat.description).toBeDefined();
+    }
+  });
+});
+
+describe("getCategoryBySlug", () => {
+  it("should return category for valid slug", () => {
+    const category = getCategoryBySlug("gaming");
+    expect(category).toBeDefined();
+    expect(category?.name).toBe("ゲーム");
+  });
+
+  it("should return undefined for invalid slug", () => {
+    expect(getCategoryBySlug("nonexistent")).toBeUndefined();
+  });
+
+  it("should return undefined for empty string", () => {
+    expect(getCategoryBySlug("")).toBeUndefined();
+  });
+});
+
+describe("getAllCategorySlugs", () => {
+  it("should return all category slugs", () => {
+    const slugs = getAllCategorySlugs();
+    expect(slugs.length).toBe(CATEGORIES.length);
+  });
+
+  it("should include known slugs", () => {
+    const slugs = getAllCategorySlugs();
+    expect(slugs).toContain("entertainment");
+    expect(slugs).toContain("gaming");
+    expect(slugs).toContain("music");
+  });
+
+  it("should return strings only", () => {
+    const slugs = getAllCategorySlugs();
+    for (const slug of slugs) {
+      expect(typeof slug).toBe("string");
+    }
+  });
+});

--- a/lib/constants/__tests__/database-errors.test.ts
+++ b/lib/constants/__tests__/database-errors.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { DB_ERROR_CODES, isPostgresError } from "../database-errors";
+
+describe("DB_ERROR_CODES", () => {
+  it("should have UNIQUE_VIOLATION code", () => {
+    expect(DB_ERROR_CODES.UNIQUE_VIOLATION).toBe("23505");
+  });
+
+  it("should have FOREIGN_KEY_VIOLATION code", () => {
+    expect(DB_ERROR_CODES.FOREIGN_KEY_VIOLATION).toBe("23503");
+  });
+
+  it("should have NOT_NULL_VIOLATION code", () => {
+    expect(DB_ERROR_CODES.NOT_NULL_VIOLATION).toBe("23502");
+  });
+
+  it("should have CHECK_VIOLATION code", () => {
+    expect(DB_ERROR_CODES.CHECK_VIOLATION).toBe("23514");
+  });
+});
+
+describe("isPostgresError", () => {
+  it("should return true for object with string code", () => {
+    expect(isPostgresError({ code: "23505" })).toBe(true);
+  });
+
+  it("should return true for error-like object with code", () => {
+    expect(isPostgresError({ code: "42P01", message: "Table not found" })).toBe(
+      true
+    );
+  });
+
+  it("should return false for null", () => {
+    expect(isPostgresError(null)).toBe(false);
+  });
+
+  it("should return false for undefined", () => {
+    expect(isPostgresError(undefined)).toBe(false);
+  });
+
+  it("should return false for string", () => {
+    expect(isPostgresError("error")).toBe(false);
+  });
+
+  it("should return false for number", () => {
+    expect(isPostgresError(42)).toBe(false);
+  });
+
+  it("should return false for object without code", () => {
+    expect(isPostgresError({ message: "error" })).toBe(false);
+  });
+
+  it("should return false for object with non-string code", () => {
+    expect(isPostgresError({ code: 123 })).toBe(false);
+  });
+});

--- a/lib/types/__tests__/guards.test.ts
+++ b/lib/types/__tests__/guards.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import {
+  isChannelObject,
+  isChannelArray,
+  extractYoutubeChannelId,
+} from "../guards";
+
+describe("isChannelObject", () => {
+  it("should return true for object with youtube_channel_id", () => {
+    expect(isChannelObject({ youtube_channel_id: "UC123" })).toBe(true);
+  });
+
+  it("should return true for object with undefined youtube_channel_id", () => {
+    expect(isChannelObject({ youtube_channel_id: undefined })).toBe(true);
+  });
+
+  it("should return false for null", () => {
+    expect(isChannelObject(null)).toBe(false);
+  });
+
+  it("should return false for undefined", () => {
+    expect(isChannelObject(undefined)).toBe(false);
+  });
+
+  it("should return false for string", () => {
+    expect(isChannelObject("UC123")).toBe(false);
+  });
+
+  it("should return false for empty object", () => {
+    expect(isChannelObject({})).toBe(false);
+  });
+
+  it("should return false for object without youtube_channel_id", () => {
+    expect(isChannelObject({ id: "123", title: "Test" })).toBe(false);
+  });
+});
+
+describe("isChannelArray", () => {
+  it("should return true for non-empty array", () => {
+    expect(isChannelArray([{ youtube_channel_id: "UC123" }])).toBe(true);
+  });
+
+  it("should return false for empty array", () => {
+    expect(isChannelArray([])).toBe(false);
+  });
+
+  it("should return false for non-array", () => {
+    expect(isChannelArray({ youtube_channel_id: "UC123" })).toBe(false);
+  });
+
+  it("should return false for null", () => {
+    expect(isChannelArray(null)).toBe(false);
+  });
+
+  it("should return false for string", () => {
+    expect(isChannelArray("UC123")).toBe(false);
+  });
+});
+
+describe("extractYoutubeChannelId", () => {
+  it("should extract from single object", () => {
+    expect(extractYoutubeChannelId({ youtube_channel_id: "UC123" })).toBe(
+      "UC123"
+    );
+  });
+
+  it("should extract from array", () => {
+    expect(extractYoutubeChannelId([{ youtube_channel_id: "UC456" }])).toBe(
+      "UC456"
+    );
+  });
+
+  it("should return undefined for null", () => {
+    expect(extractYoutubeChannelId(null)).toBeUndefined();
+  });
+
+  it("should return undefined for empty array", () => {
+    expect(extractYoutubeChannelId([])).toBeUndefined();
+  });
+
+  it("should return undefined for non-channel object", () => {
+    expect(extractYoutubeChannelId({ id: "123" })).toBeUndefined();
+  });
+
+  it("should return undefined for string", () => {
+    expect(extractYoutubeChannelId("UC123")).toBeUndefined();
+  });
+
+  it("should return first element from array with multiple items", () => {
+    expect(
+      extractYoutubeChannelId([
+        { youtube_channel_id: "UC111" },
+        { youtube_channel_id: "UC222" },
+      ])
+    ).toBe("UC111");
+  });
+});

--- a/lib/validations/__tests__/profile.test.ts
+++ b/lib/validations/__tests__/profile.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { updateProfileSchema } from "../profile";
+
+describe("updateProfileSchema", () => {
+  it("should accept valid profile data", () => {
+    const result = updateProfileSchema.safeParse({
+      displayName: "Test User",
+      bio: "Hello, world!",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept empty object (all optional)", () => {
+    const result = updateProfileSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject displayName longer than 50 chars", () => {
+    const result = updateProfileSchema.safeParse({
+      displayName: "a".repeat(51),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject bio longer than 500 chars", () => {
+    const result = updateProfileSchema.safeParse({
+      bio: "a".repeat(501),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject occupation longer than 100 chars", () => {
+    const result = updateProfileSchema.safeParse({
+      occupation: "a".repeat(101),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should accept valid gender options", () => {
+    for (const gender of ["male", "female", "other", "prefer_not_to_say"]) {
+      const result = updateProfileSchema.safeParse({ gender });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("should reject invalid gender", () => {
+    const result = updateProfileSchema.safeParse({
+      gender: "invalid",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should accept valid birth date in the past", () => {
+    const result = updateProfileSchema.safeParse({
+      birthDate: "1990-01-15",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject future birth date", () => {
+    const futureDate = new Date();
+    futureDate.setFullYear(futureDate.getFullYear() + 1);
+    const result = updateProfileSchema.safeParse({
+      birthDate: futureDate.toISOString(),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject invalid birth date string", () => {
+    const result = updateProfileSchema.safeParse({
+      birthDate: "not-a-date",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should accept empty birthDate string", () => {
+    const result = updateProfileSchema.safeParse({
+      birthDate: "",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept valid prefecture", () => {
+    const result = updateProfileSchema.safeParse({
+      prefecture: "東京都",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject invalid prefecture", () => {
+    const result = updateProfileSchema.safeParse({
+      prefecture: "InvalidPrefecture",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should accept empty prefecture string", () => {
+    const result = updateProfileSchema.safeParse({
+      prefecture: "",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept valid website URL", () => {
+    const result = updateProfileSchema.safeParse({
+      websiteUrl: "https://example.com",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept empty websiteUrl string", () => {
+    const result = updateProfileSchema.safeParse({
+      websiteUrl: "",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject invalid websiteUrl", () => {
+    const result = updateProfileSchema.safeParse({
+      websiteUrl: "not-a-url",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should accept valid avatar URL", () => {
+    const result = updateProfileSchema.safeParse({
+      avatarUrl: "https://example.com/avatar.jpg",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept empty avatarUrl string", () => {
+    const result = updateProfileSchema.safeParse({
+      avatarUrl: "",
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/lib/youtube/__tests__/cache.test.ts
+++ b/lib/youtube/__tests__/cache.test.ts
@@ -1,10 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import {
-  getCachedData,
-  setCachedData,
-  generateCacheKey,
-} from '../cache';
-import { CACHE_TTL_SECONDS } from '../types';
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getCachedData, setCachedData, generateCacheKey } from "../cache";
+import { CACHE_TTL_SECONDS } from "../types";
 
 // Supabase client mock functions
 const mockSingle = vi.fn();
@@ -29,26 +25,26 @@ const mockSupabase = {
 };
 
 // Mock @/lib/supabase/server
-vi.mock('@/lib/supabase/server', () => ({
+vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(() => Promise.resolve(mockSupabase)),
 }));
 
-describe('YouTube Cache', () => {
+describe("YouTube Cache", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-02-05T12:00:00Z'));
+    vi.setSystemTime(new Date("2026-02-05T12:00:00Z"));
   });
 
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  describe('getCachedData', () => {
-    it('should return cached data when cache is valid', async () => {
+  describe("getCachedData", () => {
+    it("should return cached data when cache is valid", async () => {
       // Arrange
-      const cacheKey = 'youtube:search:abc123';
-      const cachedData = { results: ['channel1', 'channel2'] };
+      const cacheKey = "youtube:search:abc123";
+      const cachedData = { results: ["channel1", "channel2"] };
       const expiresAt = new Date(
         Date.now() + CACHE_TTL_SECONDS * 1000
       ).toISOString();
@@ -67,13 +63,13 @@ describe('YouTube Cache', () => {
 
       // Assert
       expect(result).toEqual(cachedData);
-      expect(mockFrom).toHaveBeenCalledWith('youtube_cache');
+      expect(mockFrom).toHaveBeenCalledWith("youtube_cache");
     });
 
-    it('should return null when cache is expired', async () => {
+    it("should return null when cache is expired", async () => {
       // Arrange
-      const cacheKey = 'youtube:search:abc123';
-      const cachedData = { results: ['channel1', 'channel2'] };
+      const cacheKey = "youtube:search:abc123";
+      const cachedData = { results: ["channel1", "channel2"] };
       const expiresAt = new Date(Date.now() - 1000).toISOString(); // Expired 1 second ago
 
       mockSingle.mockResolvedValueOnce({
@@ -92,13 +88,13 @@ describe('YouTube Cache', () => {
       expect(result).toBeNull();
     });
 
-    it('should return null when cache does not exist', async () => {
+    it("should return null when cache does not exist", async () => {
       // Arrange
-      const cacheKey = 'youtube:search:nonexistent';
+      const cacheKey = "youtube:search:nonexistent";
 
       mockSingle.mockResolvedValueOnce({
         data: null,
-        error: { code: 'PGRST116' }, // Not found
+        error: { code: "PGRST116" }, // Not found
       });
 
       // Act
@@ -108,13 +104,28 @@ describe('YouTube Cache', () => {
       expect(result).toBeNull();
     });
 
-    it('should return null on Supabase errors', async () => {
+    it("should return null on Supabase errors", async () => {
       // Arrange
-      const cacheKey = 'youtube:search:error';
+      const cacheKey = "youtube:search:error";
 
       mockSingle.mockResolvedValueOnce({
         data: null,
-        error: { message: 'Connection failed', code: 'CONNECTION_ERROR' },
+        error: { message: "Connection failed", code: "CONNECTION_ERROR" },
+      });
+
+      // Act
+      const result = await getCachedData(cacheKey);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it("should return null when Supabase throws exception", async () => {
+      // Arrange
+      const cacheKey = "youtube:search:exception";
+
+      mockFrom.mockImplementationOnce(() => {
+        throw new Error("Connection failed");
       });
 
       // Act
@@ -125,11 +136,11 @@ describe('YouTube Cache', () => {
     });
   });
 
-  describe('setCachedData', () => {
-    it('should store data in cache with correct TTL', async () => {
+  describe("setCachedData", () => {
+    it("should store data in cache with correct TTL", async () => {
       // Arrange
-      const cacheKey = 'youtube:search:abc123';
-      const data = { results: ['channel1', 'channel2'] };
+      const cacheKey = "youtube:search:abc123";
+      const data = { results: ["channel1", "channel2"] };
       const expectedExpiresAt = new Date(
         Date.now() + CACHE_TTL_SECONDS * 1000
       ).toISOString();
@@ -156,14 +167,27 @@ describe('YouTube Cache', () => {
       );
     });
 
-    it('should handle upsert errors gracefully', async () => {
+    it("should handle upsert errors gracefully", async () => {
       // Arrange
-      const cacheKey = 'youtube:search:error';
+      const cacheKey = "youtube:search:error";
       const data = { results: [] };
 
       mockSingle.mockResolvedValueOnce({
         data: null,
-        error: { message: 'Upsert failed', code: 'ERROR' },
+        error: { message: "Upsert failed", code: "ERROR" },
+      });
+
+      // Act & Assert - Should not throw
+      await expect(setCachedData(cacheKey, data)).resolves.toBeUndefined();
+    });
+
+    it("should handle Supabase exception gracefully", async () => {
+      // Arrange
+      const cacheKey = "youtube:search:exception";
+      const data = { results: [] };
+
+      mockFrom.mockImplementationOnce(() => {
+        throw new Error("Connection failed");
       });
 
       // Act & Assert - Should not throw
@@ -171,11 +195,11 @@ describe('YouTube Cache', () => {
     });
   });
 
-  describe('generateCacheKey', () => {
-    it('should generate consistent cache keys for same inputs', () => {
+  describe("generateCacheKey", () => {
+    it("should generate consistent cache keys for same inputs", () => {
       // Arrange
-      const operation = 'search';
-      const params = { query: 'test', maxResults: 10 };
+      const operation = "search";
+      const params = { query: "test", maxResults: 10 };
 
       // Act
       const key1 = generateCacheKey(operation, params);
@@ -186,28 +210,37 @@ describe('YouTube Cache', () => {
       expect(key1).toMatch(/^youtube:search:[a-f0-9]{64}$/);
     });
 
-    it('should generate different keys for different operations', () => {
+    it("should generate different keys for different operations", () => {
       // Arrange
-      const params = { id: 'UC123' };
+      const params = { id: "UC123" };
 
       // Act
-      const searchKey = generateCacheKey('search', params);
-      const detailsKey = generateCacheKey('details', params);
+      const searchKey = generateCacheKey("search", params);
+      const detailsKey = generateCacheKey("details", params);
 
       // Assert
       expect(searchKey).not.toBe(detailsKey);
     });
 
-    it('should generate different keys for different params', () => {
+    it("should generate different keys for different params", () => {
       // Arrange
-      const operation = 'search';
+      const operation = "search";
 
       // Act
-      const key1 = generateCacheKey(operation, { query: 'test1' });
-      const key2 = generateCacheKey(operation, { query: 'test2' });
+      const key1 = generateCacheKey(operation, { query: "test1" });
+      const key2 = generateCacheKey(operation, { query: "test2" });
 
       // Assert
       expect(key1).not.toBe(key2);
+    });
+
+    it("should generate consistent keys regardless of param order", () => {
+      // Act
+      const key1 = generateCacheKey("search", { query: "test", limit: 10 });
+      const key2 = generateCacheKey("search", { limit: 10, query: "test" });
+
+      // Assert
+      expect(key1).toBe(key2);
     });
   });
 });


### PR DESCRIPTION
## Summary

- テストカバレッジを78%から88%に引き上げ（80%閾値を全指標で達成）
- 8つの低カバレッジモジュールに対してテストを追加（合計101テスト追加）
- 新規テストファイル6件、既存テストファイル2件を拡充

### カバレッジ改善
| 指標 | Before | After |
|------|--------|-------|
| Statements | 77.79% | **88.05%** |
| Branches | 66.73% | **80.00%** |
| Functions | 78.31% | **92.77%** |
| Lines | 78.07% | **87.97%** |

## Test plan

- [x] `npx tsc --noEmit` 型チェック通過
- [x] `npm run test:unit` 全289テスト通過
- [x] `npm run lint` エラーなし
- [x] カバレッジ閾値80%を全指標で達成

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)