### PR TITLE
docs: Add PR Scoping Enforcement section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,23 @@ const channels = await searchChannels(query, limit);
 - コード例: `.claude/examples.md` を参照
 - タスクチェックリスト: `.claude/task-checklists.md` を参照
 
+## PR Scoping Enforcement
+
+PRサイズは2つのチェックポイントで強制チェックされる。詳細手順は `.claude/task-checklists.md` を参照。
+
+### チェックポイント1: Plan mode（見積もり段階）
+
+- 実装計画に「推定変更行数・ファイル数」を必須記載
+- 推定300行超 → 分割計画を記載してから ExitPlanMode
+- 分割不可能な場合 → 理由を明記し、ユーザー承認を得る
+
+### チェックポイント2: PR作成前（実測段階）
+
+- `git diff --stat main...HEAD | tail -1` でサイズを実測
+- 300行以下 & 10ファイル以下 → PR作成続行
+- ドキュメント・テストのみ → 500行まで許容
+- 超過時 → PR作成を中断し、分割を提案
+
 ## Best Practices
 
 1. **Server Components First**: デフォルトは Server Component


### PR DESCRIPTION
## 概要

CLAUDE.md に「PR Scoping Enforcement」専用セクションを追加し、PRサイズの2段階チェック機構（Plan mode + PR作成前）を明文化。

Closes #166

## 変更内容

- `CLAUDE.md` に `## PR Scoping Enforcement` セクションを追加
  - チェックポイント1: Plan mode での推定サイズ記載ルール
  - チェックポイント2: PR作成前の `git diff --stat` による実測ルール
- 詳細手順は既存の `.claude/task-checklists.md` を参照する構成（重複を避ける）

## 背景

Critical Rules #7, #8, #9 に1行ルールは記載済みだったが、具体的な手順・判定基準をまとめた専用セクションがなかった。Issue #166 の設計に従い、セクションを追加。

## テスト計画

- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm run test:unit` 通過（293 passed）
- [x] `npm run build` 通過
- [x] PRサイズ: 1ファイル / 17行（閾値内）

🤖 Generated with [Claude Code](https://claude.com/claude-code)